### PR TITLE
feat: implement GET /audit_logs/ API

### DIFF
--- a/docs/tables/table_kolide_k2_audit_logs.md
+++ b/docs/tables/table_kolide_k2_audit_logs.md
@@ -1,0 +1,16 @@
+# Table: kolide_k2_audit_logs
+
+Lists the tracked events occurring in the Kolide web console
+
+## Examples
+
+### Basic info
+
+```sql
+select
+  timestamp,
+  description,
+  actor_name
+from
+  kolide_k2_audit_logs;
+```

--- a/kolide/client/audit_logs.go
+++ b/kolide/client/audit_logs.go
@@ -1,0 +1,24 @@
+package kolide_client
+
+import (
+	"time"
+)
+
+type AuditLogListResponse struct {
+	AuditLogs  []AuditLog `json:"data"`
+	Pagination Pagination `json:"pagination"`
+}
+type AuditLog struct {
+	Id          string    `json:"id"`
+	Timestamp   time.Time `json:"timestamp"`
+	ActorName   string    `json:"actor_name"`
+	Description string    `json:"description"`
+}
+
+func (c *Client) GetAuditLogs(cursor string, limit int32, searches ...Search) (interface{}, error) {
+	return c.fetchCollection("/audit_logs/", cursor, limit, searches, new(AuditLogListResponse))
+}
+
+func (c *Client) GetAuditLogById(id string) (interface{}, error) {
+	return c.fetchResource("/audit_logs/", id, new(AuditLog))
+}

--- a/kolide/plugin.go
+++ b/kolide/plugin.go
@@ -26,6 +26,7 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 
 		TableMap: map[string]*plugin.Table{
 			"kolide_k2_admin_user":           tableKolideK2AdminUser(ctx),
+			"kolide_k2_audit_log":            tableKolideK2AuditLog(ctx),
 			"kolide_k2_deprovisioned_person": tableKolideK2DeprovisionedPerson(ctx),
 			"kolide_k2_device":               tableKolideK2Device(ctx),
 		},

--- a/kolide/table_kolide_k2_audit_logs.go
+++ b/kolide/table_kolide_k2_audit_logs.go
@@ -1,0 +1,62 @@
+package kolide
+
+import (
+	"context"
+
+	kolide "github.com/grendel-consulting/steampipe-plugin-kolide/kolide/client"
+	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+)
+
+//// TABLE DEFINITION
+
+func tableKolideK2AuditLog(_ context.Context) *plugin.Table {
+	return &plugin.Table{
+		Name:        "kolide_k2_audit_log",
+		Description: "Tracked events occurring in the Kolide web console.",
+		Columns: []*plugin.Column{
+			// Filterable "top" columns
+			{Name: "id", Description: "Canonical identifier for this audit log event.", Type: proto.ColumnType_STRING},
+			{Name: "timestamp", Description: "When this event occurred.", Type: proto.ColumnType_TIMESTAMP},
+			{Name: "actor_name", Description: "Name of the entity triggering this event.", Type: proto.ColumnType_STRING},
+			{Name: "description", Description: "Description of the event that occurred.", Type: proto.ColumnType_STRING},
+			// Other columns
+			// Steampipe standard columns
+			{Name: "title", Description: "Display name for this event.", Type: proto.ColumnType_STRING, Transform: transform.FromField("Description")},
+		},
+		List: &plugin.ListConfig{
+			KeyColumns: []*plugin.KeyColumn{
+				// Using Kolide K2 API query feature, can be combined with AND (and OR)
+				{Name: "timestamp", Require: plugin.Optional, Operators: []string{"=", ">", "<"}},
+				{Name: "actor_name", Require: plugin.Optional, Operators: []string{"=", "~~"}},
+				{Name: "description", Require: plugin.Optional, Operators: []string{"=", "~~"}},
+			},
+			Hydrate: listAuditLogs,
+		},
+		Get: &plugin.GetConfig{
+			KeyColumns: plugin.SingleColumn("id"),
+			Hydrate:    getAuditLog,
+		},
+	}
+}
+
+//// LIST FUNCTION
+
+func listAuditLogs(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	var visitor ListPredicate = func(client *kolide.Client, cursor string, limit int32, searches ...kolide.Search) (interface{}, error) {
+		return client.GetAuditLogs(cursor, limit, searches...)
+	}
+
+	return listAnything(ctx, d, h, "kolide_k2_audit_log.listAuditLogs", visitor, "AuditLogs")
+}
+
+//// GET FUNCTION
+
+func getAuditLog(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	var visitor GetPredicate = func(client *kolide.Client, id string) (interface{}, error) {
+		return client.GetAuditLogById(id)
+	}
+
+	return getAnything(ctx, d, h, "kolide_k2_audit_log.getAuditLog", "id", visitor)
+}


### PR DESCRIPTION
closes #17, #18

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new table `kolide_k2_audit_logs` for tracking events in the Kolide web console, accessible via SQL queries.
	- Added functionality in the Kolide client for handling and retrieving audit logs.
	- New table declaration for `kolide_k2_audit_log` to facilitate interaction with audit logs, including detailed event information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->