### PR TITLE
feat: implement GET /packages/ and /packages/{id}

### DIFF
--- a/docs/tables/kolide_k2_package.md
+++ b/docs/tables/kolide_k2_package.md
@@ -1,0 +1,17 @@
+# Table: kolide_k2_package
+
+Lists the published installation packages for the Kolide Launcher agent for each major operating system.
+
+## Examples
+
+### Basic info
+
+```sql
+select
+  id,
+  built_at
+  version,
+  url
+from
+  kolide_k2_package;
+```

--- a/docs/tables/kolide_k2_package.md
+++ b/docs/tables/kolide_k2_package.md
@@ -6,10 +6,9 @@ Lists the published installation packages for the Kolide Launcher agent for each
 
 ### Basic info
 
-```sql
 select
   id,
-  built_at
+  built_at,
   version,
   url
 from

--- a/kolide/client/package.go
+++ b/kolide/client/package.go
@@ -1,0 +1,24 @@
+package kolide_client
+
+import (
+	"time"
+)
+
+type PackageListResponse struct {
+	Packages   []Package  `json:"data"`
+	Pagination Pagination `json:"pagination"`
+}
+type Package struct {
+	Id      string    `json:"id"`
+	BuiltAt time.Time `json:"built_at"`
+	URL     string    `json:"url"`
+	Version string    `json:"version"`
+}
+
+func (c *Client) GetPackages(cursor string, limit int32, searches ...Search) (interface{}, error) {
+	return c.fetchCollection("/packages/", cursor, limit, searches, new(PackageListResponse))
+}
+
+func (c *Client) GetPackageById(id string) (interface{}, error) {
+	return c.fetchResource("/packages/", id, new(Package))
+}

--- a/kolide/plugin.go
+++ b/kolide/plugin.go
@@ -29,6 +29,7 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 			"kolide_k2_audit_log":            tableKolideK2AuditLog(ctx),
 			"kolide_k2_deprovisioned_person": tableKolideK2DeprovisionedPerson(ctx),
 			"kolide_k2_device":               tableKolideK2Device(ctx),
+			"kolide_k2_package":              tableKolideK2Package(ctx),
 		},
 	}
 	return p

--- a/kolide/table_kolide_k2_package.go
+++ b/kolide/table_kolide_k2_package.go
@@ -1,0 +1,56 @@
+package kolide
+
+import (
+	"context"
+
+	kolide "github.com/grendel-consulting/steampipe-plugin-kolide/kolide/client"
+	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+)
+
+//// TABLE DEFINITION
+
+func tableKolideK2Package(_ context.Context) *plugin.Table {
+	return &plugin.Table{
+		Name:        "kolide_k2_package",
+		Description: "Installation packages for Kolide Launcher agent for each major operating system.",
+		Columns: []*plugin.Column{
+			// Filterable "top" columns
+			{Name: "id", Description: "Unique identifier for this package.", Type: proto.ColumnType_STRING},
+			// Other columns
+			{Name: "built_at", Description: "When this installation package was built.", Type: proto.ColumnType_TIMESTAMP},
+			{Name: "url", Description: "URL that can be used to download this installation package. Requests to this url require the standard Authorization header needed for all Kolide K2 API requests.", Type: proto.ColumnType_STRING},
+			{Name: "version", Description: "Version of the Launcher agent that will be installed by this package.", Type: proto.ColumnType_STRING},
+			// Steampipe standard columns
+			{Name: "title", Description: "Display name for this event.", Type: proto.ColumnType_STRING, Transform: transform.FromField("Id")},
+		},
+		List: &plugin.ListConfig{
+			Hydrate: listPackages,
+		},
+		Get: &plugin.GetConfig{
+			KeyColumns: plugin.SingleColumn("id"),
+			Hydrate:    getPackage,
+		},
+	}
+}
+
+//// LIST FUNCTION
+
+func listPackages(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	var visitor ListPredicate = func(client *kolide.Client, cursor string, limit int32, searches ...kolide.Search) (interface{}, error) {
+		return client.GetPackages(cursor, limit, searches...)
+	}
+
+	return listAnything(ctx, d, h, "kolide_k2_audit_log.listPackages", visitor, "Packages")
+}
+
+//// GET FUNCTION
+
+func getPackage(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	var visitor GetPredicate = func(client *kolide.Client, id string) (interface{}, error) {
+		return client.GetPackageById(id)
+	}
+
+	return getAnything(ctx, d, h, "kolide_k2_audit_log.getPackage", "id", visitor)
+}


### PR DESCRIPTION
closes #21 
closes #22 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
    - Introduced a detailed table listing installation packages for the Kolide Launcher agent, available across major operating systems. This includes information such as package ID, build date, version, and download URL.
    - Added functionality to the Kolide client API for managing packages, including support for pagination and fetching package details by ID.
- **Documentation**
    - Added documentation for the new `kolide_k2_package` table, outlining its purpose and the information it provides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->