### PR TITLE
feat: implement GET /issues/ and /issues/{id} and /device/{deviceId}/open_issues

### DIFF
--- a/docs/tables/kolide_k2_device_open_issue.md
+++ b/docs/tables/kolide_k2_device_open_issue.md
@@ -1,0 +1,60 @@
+# Table: kolide_k2_device_open_issue
+
+Lists the unresolved and unexempted issues created when a specific device fails a check; some checks, when they fail, will produce multiple Issues, each with a unique primary_key_value.
+
+You will need to provide a valid `device_id` for all queries to this table.
+
+## Examples
+
+### Basic info
+
+```sql
+select
+  title,
+  detected_at,
+  blocks_device_at,
+  resolved_at,
+  exempted
+from
+  kolide_k2_device_open_issue
+where
+  device_id = '1553';
+```
+
+### List all device-blocking issues
+
+```sql
+select
+  title,
+  detected_at,
+  value
+from
+  kolide_k2_device_open_issue
+where
+  device_id = '1553'
+  and
+  blocks_device_at is not null;
+```
+
+### Diagnose specific issues with battery health
+
+Batteries in most modern laptops have a recharging "cycle count", after which the battery is considered to be fully consumed
+
+```sql
+select
+  d.name,
+  d.hardware_model,
+  d.serial,
+  o.value->'cycle_count' as battery_cycles,
+  o.value->'health' as battery_health,
+  o.value->'max_capacity' as battery_max
+from
+  kolide_k2_device_open_issue o,
+  kolide_k2_device d
+where
+  o.check_id = '15804'
+  and
+  o.device_id = d.id
+  and
+  o.device_id = '1553';
+ ```

--- a/docs/tables/kolide_k2_device_open_issue.md
+++ b/docs/tables/kolide_k2_device_open_issue.md
@@ -1,6 +1,6 @@
 # Table: kolide_k2_device_open_issue
 
-Lists the unresolved and unexempted issues created when a specific device fails a check; some checks, when they fail, will produce multiple Issues, each with a unique primary_key_value.
+Lists the unresolved and unexempted issues created when a specific device fails a check; some checks, when they fail, will produce multiple issues, each with a unique primary_key_value.
 
 You will need to provide a valid `device_id` for all queries to this table.
 

--- a/docs/tables/kolide_k2_issue.md
+++ b/docs/tables/kolide_k2_issue.md
@@ -1,0 +1,71 @@
+# Table: kolide_k2_issue
+
+Lists the issues created when a device fails a check; some checks, when they fail, will produce multiple Issues, each with a unique primary_key_value.
+
+## Examples
+
+### Basic info
+
+```sql
+select
+  title,
+  detected_at,
+  blocks_device_at,
+  resolved_at,
+  exempted
+from
+  kolide_k2_issue;
+```
+
+### List all unresolved issues
+
+```sql
+select
+  title,
+  detected_at,
+  value
+from
+  kolide_k2_issue
+where
+  resolved_at is null;
+```
+
+### List all device-blocking issues
+
+```sql
+select
+  title,
+  detected_at,
+  value
+from
+  kolide_k2_issue
+where
+  blocks_device_at is not null;
+```
+
+### List all ignored issues
+
+```sql
+select
+  title,
+  detected_at,
+  value
+from
+  kolide_k2_issue
+where
+  exempted = true;
+```
+
+### List devices with open issues
+
+```sql
+select
+  device_id,
+  count(device_id) as count
+from
+  kolide_k2_issue
+where
+  resolved_at is null
+group by
+  device_id;
+```

--- a/kolide/client/devices.go
+++ b/kolide/client/devices.go
@@ -48,3 +48,7 @@ func (c *Client) GetDevices(cursor string, limit int32, searches ...Search) (int
 func (c *Client) GetDeviceById(id string) (interface{}, error) {
 	return c.fetchResource("/devices/", id, new(Device))
 }
+
+func (c *Client) GetIssuesByDevice(id string, cursor string, limit int32, searches ...Search) (interface{}, error) {
+	return c.fetchCollectionWithResourceId("/devices/{resourceId}/open_issues", id, cursor, limit, searches, new(IssueListResponse))
+}

--- a/kolide/client/fetch.go
+++ b/kolide/client/fetch.go
@@ -32,3 +32,21 @@ func (c *Client) fetchResource(path string, resourceId string, target interface{
 
 	return target, nil
 }
+
+func (c *Client) fetchCollectionWithResourceId(path string, id string, cursor string, limit int32, searches []Search, target interface{}, friendlies ...map[string]string) (interface{}, error) {
+	params := make(map[string]string)
+	params["query"] = serializeSearches(searches, friendlies...)
+
+	if cursor != "" {
+		params["per_page"] = strconv.Itoa(int(limit))
+		params["cursor"] = cursor
+	}
+
+	err := c.c.Get(path).SetPathParam("resourceId", id).SetQueryParams(params).Do().Into(&target)
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve collection at %s with response: %q", path, err)
+	}
+
+	return target, nil
+}

--- a/kolide/client/issues.go
+++ b/kolide/client/issues.go
@@ -1,0 +1,43 @@
+package kolide_client
+
+import (
+	"encoding/json"
+	"time"
+)
+
+type IssueListResponse struct {
+	Issues     []Issue    `json:"data"`
+	Pagination Pagination `json:"pagination"`
+}
+type Issue struct {
+	Id                string            `json:"id"`
+	IssueKey          string            `json:"issue_key,omitempty"`
+	IssueValue        string            `json:"issue_value,omitempty"`
+	Title             string            `json:"title"`
+	Value             json.RawMessage   `json:"value,omitempty"`
+	Exempted          bool              `json:"exempted"`
+	ResolvedAt        time.Time         `json:"resolved_at,omitempty"`
+	DetectedAt        time.Time         `json:"detected_at"`
+	BlocksDeviceAt    time.Time         `json:"blocks_device_at,omitempty"`
+	DeviceInformation DeviceInformation `json:"device_information,omitempty"`
+	CheckInformation  CheckInformation  `json:"check_information,omitempty"`
+	LastRecheckedAt   time.Time         `json:"last_rechecked_at,omitempty"`
+}
+
+type DeviceInformation struct {
+	// Whilst the Kolide K2 API readme entry references this as a "string", the returned value encountered in testing is an "int"
+	Identifier int32 `json:"identifier,omitempty"`
+}
+
+type CheckInformation struct {
+	// Whilst the Kolide K2 API readme entry references this as a "string", the returned value encountered in testing is an "int"
+	Identifier int32 `json:"identifier,omitempty"`
+}
+
+func (c *Client) GetIssues(cursor string, limit int32, searches ...Search) (interface{}, error) {
+	return c.fetchCollection("/issues/", cursor, limit, searches, new(IssueListResponse))
+}
+
+func (c *Client) GetIssueById(id string) (interface{}, error) {
+	return c.fetchResource("/issues/", id, new(Issue))
+}

--- a/kolide/plugin.go
+++ b/kolide/plugin.go
@@ -30,6 +30,8 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 			"kolide_k2_check":                tableKolideK2Check(ctx),
 			"kolide_k2_deprovisioned_person": tableKolideK2DeprovisionedPerson(ctx),
 			"kolide_k2_device":               tableKolideK2Device(ctx),
+			"kolide_k2_device_open_issue":    tableKolideK2DeviceOpenIssue(ctx),
+			"kolide_k2_issue":                tableKolideK2Issue(ctx),
 			"kolide_k2_package":              tableKolideK2Package(ctx),
 		},
 	}

--- a/kolide/table_kolide_k2_device.go
+++ b/kolide/table_kolide_k2_device.go
@@ -24,7 +24,7 @@ func tableKolideK2Device(_ context.Context) *plugin.Table {
 			{Name: "serial", Description: "Hardware serial for the device.", Type: proto.ColumnType_STRING},
 			{Name: "hardware_uuid", Description: "Hardware UUID for the device.", Type: proto.ColumnType_STRING},
 			{Name: "note", Description: "Notes provided by a Kolide administrator (in Markdown format).", Type: proto.ColumnType_STRING},
-			{Name: "will_block_at", Description: "If the auth status is 'Will Block', this timestampe describes when the device will be blocked by a failing check.", Type: proto.ColumnType_TIMESTAMP},
+			{Name: "will_block_at", Description: "If the auth status is 'Will Block', this timestamp describes when the device will be blocked by a failing check.", Type: proto.ColumnType_TIMESTAMP},
 			{Name: "device_type", Description: "Platform type of the device, one of Mac, Windows, Linux, iOS or Android.", Type: proto.ColumnType_STRING},
 			// Other columns
 			{Name: "registered_owner_identifier", Description: "Canonical identifier for the registered owner of this device.", Type: proto.ColumnType_STRING},

--- a/kolide/table_kolide_k2_device_open_issues.go
+++ b/kolide/table_kolide_k2_device_open_issues.go
@@ -1,0 +1,63 @@
+package kolide
+
+import (
+	"context"
+
+	kolide "github.com/grendel-consulting/steampipe-plugin-kolide/kolide/client"
+	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+)
+
+//// TABLE DEFINITION
+
+func tableKolideK2DeviceOpenIssue(_ context.Context) *plugin.Table {
+	return &plugin.Table{
+		Name:        "kolide_k2_device_open_issue",
+		Description: "Unresolved and non-exempt issues created when a specific device fails a check; some checks, when they fail, will produce multiple Issues, each with a unique primary_key_value.",
+		Columns: []*plugin.Column{
+			// Filterable "top" columns
+			{Name: "id", Description: "Canonical identifier for this issue.", Type: proto.ColumnType_STRING},
+			{Name: "issue_key", Description: "Primary key that distinguishes one issue from another in the context of a single check; only applicable for checks that can produce multiple issues.", Type: proto.ColumnType_STRING},
+			{Name: "issue_value", Description: "Primary identifying value that distinguishes one issue from another in the context of a single check; only applicable for checks that can produce multiple issues.", Type: proto.ColumnType_STRING},
+			{Name: "title", Description: "Descriptive title for this issue.", Type: proto.ColumnType_STRING},
+			{Name: "exempted", Description: "Whether this issue has been granted an exemption.", Type: proto.ColumnType_BOOL},
+			{Name: "resolved_at", Description: "When this issue was resolved, or null if still open.", Type: proto.ColumnType_TIMESTAMP},
+			{Name: "detected_at", Description: "When this issue was initially detected.", Type: proto.ColumnType_TIMESTAMP},
+			{Name: "blocks_device_at", Description: "When the device will be blocked from authenticating by this failing issue, or null if the check is not configured to block authentication.", Type: proto.ColumnType_TIMESTAMP},
+			{Name: "device_id", Description: "Canonical identifier for the device this issue relates to.", Type: proto.ColumnType_STRING, Transform: transform.FromField("DeviceInformation.Identifier")},
+			{Name: "check_id", Description: "Canonical identifier for the check this issue relates to.", Type: proto.ColumnType_STRING, Transform: transform.FromField("CheckInformation.Identifier")},
+			{Name: "last_rechecked_at", Description: "When this issue was last rechecked.", Type: proto.ColumnType_TIMESTAMP},
+			// Other columns
+			{Name: "value", Description: "Relevant data that describes why the device failed the check.", Type: proto.ColumnType_JSON},
+			// Steampipe standard columns
+			// - We include "title" above as an expected Kolide K2 API column, and it is sufficient
+		},
+		List: &plugin.ListConfig{
+			KeyColumns: []*plugin.KeyColumn{
+				{Name: "device_id", Require: plugin.Required, Operators: []string{"="}},
+				// Using Kolide K2 API query feature, can be combined with AND (and OR)
+				{Name: "issue_key", Require: plugin.Optional, Operators: []string{"=", "~~"}},
+				{Name: "issue_value", Require: plugin.Optional, Operators: []string{"=", "~~"}},
+				{Name: "title", Require: plugin.Optional, Operators: []string{"=", "~~"}},
+				{Name: "exempted", Require: plugin.Optional, Operators: []string{"="}},
+				{Name: "resolved_at", Require: plugin.Optional, Operators: []string{"=", ">", "<"}},
+				{Name: "detected_at", Require: plugin.Optional, Operators: []string{"=", ">", "<"}},
+				{Name: "blocks_device_at", Require: plugin.Optional, Operators: []string{"=", ">", "<"}},
+				{Name: "check_id", Require: plugin.Optional, Operators: []string{"=", "~~"}},
+				{Name: "last_rechecked_at", Require: plugin.Optional, Operators: []string{"=", "~~"}},
+			},
+			Hydrate: listIssuesByDevice,
+		},
+	}
+}
+
+//// LIST FUNCTION
+
+func listIssuesByDevice(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	var visitor ListByIdPredicate = func(client *kolide.Client, id string, cursor string, limit int32, searches ...kolide.Search) (interface{}, error) {
+		return client.GetIssuesByDevice(id, cursor, limit, searches...)
+	}
+
+	return listAnythingById(ctx, d, h, "kolide_k2_issue.listIssuesByDevice", "device_id", visitor, "Issues")
+}

--- a/kolide/table_kolide_k2_issue.go
+++ b/kolide/table_kolide_k2_issue.go
@@ -1,0 +1,77 @@
+package kolide
+
+import (
+	"context"
+
+	kolide "github.com/grendel-consulting/steampipe-plugin-kolide/kolide/client"
+	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+)
+
+//// TABLE DEFINITION
+
+func tableKolideK2Issue(_ context.Context) *plugin.Table {
+	return &plugin.Table{
+		Name:        "kolide_k2_issue",
+		Description: "Issues created when a device fails a check; some checks, when they fail, will produce multiple Issues, each with a unique primary_key_value.",
+		Columns: []*plugin.Column{
+			// Filterable "top" columns
+			{Name: "id", Description: "Canonical identifier for this issue.", Type: proto.ColumnType_STRING},
+			{Name: "issue_key", Description: "Primary key that distinguishes one issue from another in the context of a single check; only applicable for checks that can produce multiple issues.", Type: proto.ColumnType_STRING},
+			{Name: "issue_value", Description: "Primary identifying value that distinguishes one issue from another in the context of a single check; only applicable for checks that can produce multiple issues.", Type: proto.ColumnType_STRING},
+			{Name: "title", Description: "Descriptive title for this issue.", Type: proto.ColumnType_STRING},
+			{Name: "exempted", Description: "Whether this issue has been granted an exemption.", Type: proto.ColumnType_BOOL},
+			{Name: "resolved_at", Description: "When this issue was resolved, or null if still open.", Type: proto.ColumnType_TIMESTAMP},
+			{Name: "detected_at", Description: "When this issue was initially detected.", Type: proto.ColumnType_TIMESTAMP},
+			{Name: "blocks_device_at", Description: "When the device will be blocked from authenticating by this failing issue, or null if the check is not configured to block authentication.", Type: proto.ColumnType_TIMESTAMP},
+			{Name: "device_id", Description: "Canonical identifier for the device this issue relates to.", Type: proto.ColumnType_STRING, Transform: transform.FromField("DeviceInformation.Identifier")},
+			{Name: "check_id", Description: "Canonical identifier for the check this issue relates to.", Type: proto.ColumnType_STRING, Transform: transform.FromField("CheckInformation.Identifier")},
+			{Name: "last_rechecked_at", Description: "When this issue was last rechecked.", Type: proto.ColumnType_TIMESTAMP},
+			// Other columns
+			{Name: "value", Description: "Relevant data that describes why the device failed the check.", Type: proto.ColumnType_JSON},
+			// Steampipe standard columns
+			// - We include "title" above as an expected Kolide K2 API column, and it is sufficient
+		},
+		List: &plugin.ListConfig{
+			KeyColumns: []*plugin.KeyColumn{
+				// Using Kolide K2 API query feature, can be combined with AND (and OR)
+				{Name: "issue_key", Require: plugin.Optional, Operators: []string{"=", "~~"}},
+				{Name: "issue_value", Require: plugin.Optional, Operators: []string{"=", "~~"}},
+				{Name: "title", Require: plugin.Optional, Operators: []string{"=", "~~"}},
+				{Name: "exempted", Require: plugin.Optional, Operators: []string{"="}},
+				{Name: "resolved_at", Require: plugin.Optional, Operators: []string{"=", ">", "<"}},
+				{Name: "detected_at", Require: plugin.Optional, Operators: []string{"=", ">", "<"}},
+				{Name: "blocks_device_at", Require: plugin.Optional, Operators: []string{"=", ">", "<"}},
+				// {Name: "device_id", Require: plugin.Optional, Operators: []string{"=", "~~"}},
+				// {Name: "check_id", Require: plugin.Optional, Operators: []string{"=", "~~"}},
+				{Name: "last_rechecked_at", Require: plugin.Optional, Operators: []string{"=", "~~"}},
+			},
+			Hydrate: listIssues,
+		},
+		Get: &plugin.GetConfig{
+			KeyColumns: plugin.SingleColumn("id"),
+			Hydrate:    getIssue,
+		},
+	}
+}
+
+//// LIST FUNCTION
+
+func listIssues(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	var visitor ListPredicate = func(client *kolide.Client, cursor string, limit int32, searches ...kolide.Search) (interface{}, error) {
+		return client.GetIssues(cursor, limit, searches...)
+	}
+
+	return listAnything(ctx, d, h, "kolide_k2_issue.listIssues", visitor, "Issues")
+}
+
+//// GET FUNCTION
+
+func getIssue(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	var visitor GetPredicate = func(client *kolide.Client, id string) (interface{}, error) {
+		return client.GetIssueById(id)
+	}
+
+	return getAnything(ctx, d, h, "kolide_k2_issue.getIssue", "id", visitor)
+}

--- a/kolide/utils.go
+++ b/kolide/utils.go
@@ -41,6 +41,7 @@ func connect(ctx context.Context, d *plugin.QueryData) (*kolide.Client, error) {
 
 type ListPredicate func(client *kolide.Client, cursor string, limit int32, searches ...kolide.Search) (interface{}, error)
 type GetPredicate func(client *kolide.Client, id string) (interface{}, error)
+type ListByIdPredicate func(client *kolide.Client, id string, cursor string, limit int32, searches ...kolide.Search) (interface{}, error)
 
 func listAnything(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData, callee string, visitor ListPredicate, target string) (interface{}, error) {
 	// Create a slice to hold search queries
@@ -126,6 +127,73 @@ func getAnything(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData
 
 	return res, nil
 
+}
+
+func listAnythingById(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData, callee string, id string, visitor ListByIdPredicate, target string) (interface{}, error) {
+	// Fail early if unique identifier is not present
+	uid := d.EqualsQualString(id)
+	if uid == "" {
+		return nil, nil
+	}
+	// Create a slice to hold search queries
+	searches, err := query(ctx, d)
+	if err != nil {
+		plugin.Logger(ctx).Error(callee, "qualifier_operator_error", err)
+		return nil, err
+	}
+
+	// Establish connection to Kolide client
+	client, err := connect(ctx, d)
+	if err != nil {
+		plugin.Logger(ctx).Error(callee, "connection_error", err)
+		return nil, err
+	}
+
+	// Iterate through pagination cursors, with smallest number of pages
+	var maxLimit int32 = kolide.MaxPaging
+	if d.QueryContext.Limit != nil {
+		limit := int32(*d.QueryContext.Limit)
+		if limit < maxLimit {
+			maxLimit = limit
+		}
+	}
+
+	cursor := ""
+
+	for {
+		// Respect rate limiting
+		d.WaitForListRateLimit(ctx)
+
+		res, err := visitor(client, uid, cursor, maxLimit, searches...)
+		if err != nil {
+			plugin.Logger(ctx).Error(callee, err)
+			return nil, err
+		}
+
+		// Stream retrieved results
+		collection := reflect.ValueOf(res).Elem().FieldByName(target)
+		if collection.IsValid() {
+			for i := 0; i < collection.Len(); i++ {
+				d.StreamListItem(ctx, collection.Index(i).Interface())
+
+				// Context can be cancelled due to manual cancellation or the limit has been hit
+				if d.RowsRemaining(ctx) == 0 {
+					return nil, nil
+				}
+			}
+		}
+
+		next := reflect.ValueOf(res).Elem().FieldByName("Pagination").FieldByName("NextCursor")
+		if next.IsValid() {
+			cursor = next.Interface().(string)
+		}
+
+		if cursor == "" {
+			break
+		}
+	}
+
+	return nil, nil
 }
 
 func query(ctx context.Context, d *plugin.QueryData) ([]kolide.Search, error) {


### PR DESCRIPTION
closes #11
closes #13
closes #19 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced issue tracking and management by introducing new tables to list unresolved and unexempted issues for devices failing checks.
	- Improved visibility by adding functionality to retrieve issues related to a specific device using its ID.
- **Bug Fixes**
	- Corrected a description typo in the "will_block_at" column to accurately reflect the device blocking timestamp.
- **Documentation**
	- Updated documentation with examples and detailed information on new tables and issue management capabilities.
- **Refactor**
	- Streamlined fetching and managing of issues and device information with new methods and functions to enhance API efficiency and usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->