### PR TITLE
chore: rename to omit K2 since that was confusing folks

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature-request---new-table.md
+++ b/.github/ISSUE_TEMPLATE/feature-request---new-table.md
@@ -1,7 +1,7 @@
 ---
 name: Feature Request - New Table
 about: Suggest a new table for this plugin
-title: Add table kolide_k2_<resource>
+title: Add table kolide_<resource>
 labels: enhancement
 assignees: ""
 ---

--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -6,6 +6,10 @@ forum or through the Steampipe Slack community. If you can't find what you're
 looking for there, consider raising an
 [issue](https://github.com/grendel-consulting/steampipe-kolide-plugin/issues/new/choose)
 
+## Kolide API Version
+
+We support calls made to the Kolide API == v2023-05-26
+
 ## Steampipe Version
 
 We support this plugin in versions of Steampipe >= 0.21, which was current when this project started

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v0.2.1 [2024-04-11]
+
+_What's new?_
+
+- Renamed tables to omit "k2", i.e. it is now simply `kolide_device`
+
 ## v0.2.0 [2024-04-05]
 
 _What's new?_

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Kolide plugin for Steampipe
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/8741/badge)](https://www.bestpractices.dev/projects/8741)[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/grendel-consulting/steampipe-plugin-kolide/badge)](https://securityscorecards.dev/viewer/?uri=github.com/grendel-consulting/steampipe-plugin-kolide)[![Go Report Card](https://goreportcard.com/badge/github.com/grendel-consulting/steampipe-plugin-kolide)](https://goreportcard.com/report/github.com/grendel-consulting/steampipe-plugin-kolide)
 
-Use SQL to query Devices, People, Checks, Issues and more across your [Kolide](https://www.kolide.com/) fleet. Built atop the [Kolide K2 API](https://www.kolide.com/docs/developers/api).
+Use SQL to query Devices, People, Checks, Issues and more across your [Kolide](https://www.kolide.com/) fleet. Built atop the [Kolide API](https://www.kolide.com/docs/developers/api).
 
 ## Quick Start
 
@@ -14,7 +14,7 @@ steampipe plugin install grendel-consulting/kolide
 Create your Kolide API token and config your connection in `~/.steampipe/config/kolide.spc`
 
 ```zsh
-steampipe query "select name,hardware_model,serial from kolide_k2_device;"
+steampipe query "select name,hardware_model,serial from kolide_device;"
 ```
 
 ## Development

--- a/config/kolide.spc
+++ b/config/kolide.spc
@@ -1,7 +1,7 @@
 connection "kolide" {
   plugin = "grendel-consulting/kolide"
 
-  # Your Kolide K2 API token. Required.
+  # Your Kolide API token. Required.
   # Get your API token from Kolide, instructions here: https://www.kolide.com/docs/developers/api#creating-an-api-key.
   # Alternately you set with the `KOLIDE_API_TOKEN` environment variable.
   # api_token = "k2sk_v1_thisIsOurExampleToken"

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
 organization: Grendel Consulting
 category: ["asset management"]
 brand_color: "#7450F6"
-display_name: Kolide K2
+display_name: Kolide
 name: kolide
 description: Kolide gives you accurate, valuable and complete fleet visibility across Mac, Windows and Linux endpoints
 og_description: Query Kolide with SQL! Open source CLI. No DB required.
@@ -16,17 +16,17 @@ icon_url: "/images/plugins/grendel-consulting/kolide.svg"
 
 [Steampipe](https://steampipe.io) is an open-source zero-ETL engine to instantly query cloud APIs using SQL.
 
-This is an unofficial plugin, leveraging the public [Kolide K2 API](https://www.kolide.com/docs/developers/api) through the Steampipe engine. Prospective users are encouraged to undergo their usual due diligence in using third-party software.
+This is an unofficial plugin, leveraging the public [Kolide API](https://www.kolide.com/docs/developers/api) through the Steampipe engine. Prospective users are encouraged to undergo their usual due diligence in using third-party software.
 
 List all devices monitored by Kolide
 
 ```sql
 select
   id,
-  serial, 
+  serial,
   name
 from
-  kolide_k2_device
+  kolide_device
 ```
 ```
 +------+------------+---------+
@@ -69,7 +69,7 @@ Configure your account details in `~/.steampipe/config/kolide.spc`:
 connection "kolide" {
   plugin = "grendel-consulting/kolide"
 
-  # Your Kolide K2 API key. Required.
+  # Your Kolide API key. Required.
   # Get your API key from Kolide, instructions here: https://www.kolide.com/docs/developers/api#creating-an-api-key.
   # Alternately you set with the `KOLIDE_API_TOKEN` environment variable.
   # api_key = "k2sk_v1_thisIsOurExampleKey"
@@ -84,12 +84,12 @@ export KOLIDE_K2_TOKEN=k2sk_v1_thisIsOurExampleKey
 
 ### Rate Limiting
 
-Rate limiting is applied across the Kolide K2 API as a whole, with a **maximum of 270 requests per minute**. Retries and backoffs are handled within the plugin; however, you may want to set a sensible concurrency limit for heavier uses. You can read up in more detail under [Limiters](https://steampipe.io/docs/guides/limiter)
+Rate limiting is applied across the Kolide API as a whole, with a **maximum of 270 requests per minute**. Retries and backoffs are handled within the plugin; however, you may want to set a sensible concurrency limit for heavier uses. You can read up in more detail under [Limiters](https://steampipe.io/docs/guides/limiter)
 
 ```hcl
 plugin "kolide" {
   limiter "kolide_global_rate_limit" {
-    max_concurrency = 30 
+    max_concurrency = 30
   }
 }
 ```

--- a/docs/tables/kolide_admin_user.md
+++ b/docs/tables/kolide_admin_user.md
@@ -1,4 +1,4 @@
-# Table: kolide_k2_admin_user
+# Table: kolide_admin_user
 
 Lists the users with access to the Kolide dashboard. Depending on your organization's restrictions, they are able to view and manage checks, devices, users, and other settings.
 
@@ -14,16 +14,16 @@ select
   access,
   created_at
 from
-  kolide_k2_admin_user;
+  kolide_admin_user;
 ```
 
 ### List all Kolide super admins
 
 ```sql
-select 
+select
   email
 from
-  kolide_k2_admin_user
+  kolide_admin_user
 where
   access = 'full';
 ```
@@ -38,8 +38,8 @@ select
   access,
   created_at
 from
-  kolide_k2_admin_user
-where 
+  kolide_admin_user
+where
   email not like '%@grendel-consulting.com';
 ```
 
@@ -53,7 +53,7 @@ select
   access,
   created_at
 from
-  kolide_k2_admin_user
-where 
+  kolide_admin_user
+where
   created_at > date_trunc('day', current_date) - interval '1 week';
 ```

--- a/docs/tables/kolide_audit_log.md
+++ b/docs/tables/kolide_audit_log.md
@@ -1,4 +1,4 @@
-# Table: kolide_k2_audit_logs
+# Table: kolide_audit_logs
 
 Lists the tracked events occurring in the Kolide web console.
 
@@ -12,30 +12,30 @@ select
   description,
   actor_name
 from
-  kolide_k2_audit_logs;
+  kolide_audit_logs;
 ```
 
 ### List all events from the past day
 
 ```sql
-select 
-  timestamp, 
-  description, 
+select
+  timestamp,
+  description,
   actor_name
-from 
-  kolide_k2_audit_log 
-where 
+from
+  kolide_audit_log
+where
   timestamp > date_trunc('day', current_date) - interval '1 day';
 ```
 
 ### List all events performed by a specific user
 
 ```sql
-select 
-  timestamp, 
-  description, 
-from 
-  kolide_k2_audit_log 
+select
+  timestamp,
+  description,
+from
+  kolide_audit_log
 where
   actor_name = 'Dennis Nedry';
 ```

--- a/docs/tables/kolide_check.md
+++ b/docs/tables/kolide_check.md
@@ -1,4 +1,4 @@
-# Table: kolide_k2_check
+# Table: kolide_check
 
 Lists the checks that Kolide runs on a device on a regular cadence, which are tests that typically produce a passing or failing result.
 
@@ -7,42 +7,42 @@ Lists the checks that Kolide runs on a device on a regular cadence, which are te
 ### Basic info
 
 ```sql
-select 
-  id, 
-  name, 
-  topics, 
-  compatible_platforms, 
-  targeted_groups, 
-  blocking_group_names, 
+select
+  id,
+  name,
+  topics,
+  compatible_platforms,
+  targeted_groups,
+  blocking_group_names,
   blocking_enabled
-from 
-  kolide_k2_check;
+from
+  kolide_check;
 ```
 
 ### List all the checks relating to a specific operating system
 
 ```sql
 select
-  id, 
-  name, 
-  topics, 
-  compatible_platforms, 
-  targeted_groups, 
-  blocking_group_names, 
+  id,
+  name,
+  topics,
+  compatible_platforms,
+  targeted_groups,
+  blocking_group_names,
   blocking_enabled
-from 
-  kolide_k2_check 
-where 
+from
+  kolide_check
+where
   compatible_platforms @> '["darwin"]';
 ```
 
 ### List all the topics that Kolide breaks checks down into
 
 ```sql
-select 
+select
   distinct topic
-from 
-  kolide_k2_check,
+from
+  kolide_check,
   jsonb_array_elements_text(topics) as topic;
 ```
 
@@ -50,15 +50,15 @@ from
 
 ```sql
 select
-  id, 
-  name, 
-  topics, 
-  compatible_platforms, 
-  targeted_groups, 
-  blocking_group_names, 
+  id,
+  name,
+  topics,
+  compatible_platforms,
+  targeted_groups,
+  blocking_group_names,
   blocking_enabled
-from 
-  kolide_k2_check 
-where 
+from
+  kolide_check
+where
   topics @> '["remote-services"]';
 ```

--- a/docs/tables/kolide_deprovisioned_person.md
+++ b/docs/tables/kolide_deprovisioned_person.md
@@ -1,4 +1,4 @@
-# Table: kolide_k2_deprovisioned_person
+# Table: kolide_deprovisioned_person
 
 Lists anyone who has been removed from Kolide via SCIM.
 
@@ -11,7 +11,7 @@ select
   name,
   email
 from
-  kolide_k2_deprovisioned_person;
+  kolide_deprovisioned_person;
 ```
 
 ### List all deprovisioned people who still have a device
@@ -22,8 +22,8 @@ select
   email,
   last_authenticated_at
 from
-  kolide_k2_deprovisioned_person
-where 
+  kolide_deprovisioned_person
+where
   has_registered_device = 'true';
 ```
 
@@ -35,8 +35,8 @@ select
   email,
   last_authenticated_at
 from
-  kolide_k2_deprovisioned_person
-where 
+  kolide_deprovisioned_person
+where
   last_authenticated_at > date_trunc('day', current_date) - interval '1 week';
 ```
 
@@ -49,7 +49,7 @@ select
   name,
   email
 from
-  kolide_k2_deprovisioned_person
-where 
+  kolide_deprovisioned_person
+where
   created_at is null;
 ```

--- a/docs/tables/kolide_device.md
+++ b/docs/tables/kolide_device.md
@@ -1,4 +1,4 @@
-# Table: kolide_k2_device
+# Table: kolide_device
 
 Lists the devices that have been enrolled in Kolide.
 
@@ -12,7 +12,7 @@ select
   hardware_model,
   serial
 from
-  kolide_k2_device;
+  kolide_device;
 ```
 
 ### List all devices that are in a failed or failing auth state
@@ -23,7 +23,7 @@ select
   registered_owner_identifier,
   will_block_at
 from
-  kolide_k2_device
+  kolide_device
 where
   auth_state != 'Good'
 order by
@@ -37,11 +37,11 @@ select
   name,
   registered_owner_identifier,
   serial
-from 
-  kolide_k2_device 
-where 
-  device_type = 'Mac' 
-  and 
+from
+  kolide_device
+where
+  device_type = 'Mac'
+  and
   operating_system not like '%Sonoma%';
 ```
 
@@ -52,11 +52,11 @@ select
   name,
   registered_owner_identifier,
   serial
-from 
-  kolide_k2_device 
-where 
-  device_type = 'Mac' 
-  and 
+from
+  kolide_device
+where
+  device_type = 'Mac'
+  and
   operating_system not like '%14.4%'
 ```
 
@@ -71,7 +71,7 @@ select
   serial,
   hardware_model
 from
-  kolide_k2_device
+  kolide_device
 where
   device_type = 'Mac'
   and

--- a/docs/tables/kolide_device_open_issue.md
+++ b/docs/tables/kolide_device_open_issue.md
@@ -1,4 +1,4 @@
-# Table: kolide_k2_device_open_issue
+# Table: kolide_device_open_issue
 
 Lists the unresolved and unexempted issues created when a specific device fails a check; some checks, when they fail, will produce multiple issues, each with a unique primary_key_value.
 
@@ -16,7 +16,7 @@ select
   resolved_at,
   exempted
 from
-  kolide_k2_device_open_issue
+  kolide_device_open_issue
 where
   device_id = '1553';
 ```
@@ -29,7 +29,7 @@ select
   detected_at,
   value
 from
-  kolide_k2_device_open_issue
+  kolide_device_open_issue
 where
   device_id = '1553'
   and
@@ -49,8 +49,8 @@ select
   o.value->'health' as battery_health,
   o.value->'max_capacity' as battery_max
 from
-  kolide_k2_device_open_issue o,
-  kolide_k2_device d
+  kolide_device_open_issue o,
+  kolide_device d
 where
   o.check_id = '15804'
   and

--- a/docs/tables/kolide_issue.md
+++ b/docs/tables/kolide_issue.md
@@ -1,4 +1,4 @@
-# Table: kolide_k2_issue
+# Table: kolide_issue
 
 Lists the issues created when a device fails a check; some checks, when they fail, will produce multiple Issues, each with a unique primary_key_value.
 
@@ -14,7 +14,7 @@ select
   resolved_at,
   exempted
 from
-  kolide_k2_issue;
+  kolide_issue;
 ```
 
 ### List all unresolved issues
@@ -25,7 +25,7 @@ select
   detected_at,
   value
 from
-  kolide_k2_issue
+  kolide_issue
 where
   resolved_at is null;
 ```
@@ -38,7 +38,7 @@ select
   detected_at,
   value
 from
-  kolide_k2_issue
+  kolide_issue
 where
   blocks_device_at is not null;
 ```
@@ -51,7 +51,7 @@ select
   detected_at,
   value
 from
-  kolide_k2_issue
+  kolide_issue
 where
   exempted = true;
 ```
@@ -63,7 +63,7 @@ select
   device_id,
   count(device_id) as count
 from
-  kolide_k2_issue
+  kolide_issue
 where
   resolved_at is null
 group by

--- a/docs/tables/kolide_package.md
+++ b/docs/tables/kolide_package.md
@@ -1,4 +1,4 @@
-# Table: kolide_k2_package
+# Table: kolide_package
 
 Lists the published installation packages for the Kolide Launcher agent for each major operating system.
 
@@ -13,28 +13,28 @@ select
   version,
   url
 from
-  kolide_k2_package;
+  kolide_package;
 ```
 
 ### Find me which installers have had recent releases
 
 ```sql
-select 
-  id, 
-  version 
-from 
-  kolide_k2_package 
-where 
+select
+  id,
+  version
+from
+  kolide_package
+where
   built_at > date_trunc('day', current_date) - interval '4 weeks';
 ```
 
 ### Find me the installer url for macOS
 
 ```sql
-select 
-  url 
+select
+  url
 from
-  kolide_k2_package 
-where 
+  kolide_package
+where
   id like 'darwin%';
 ```

--- a/kolide/client/checks.go
+++ b/kolide/client/checks.go
@@ -38,7 +38,7 @@ func (c *Client) GetChecks(cursor string, limit int32, searches ...Search) (inte
 	var friendlies = map[string]string{
 		"description": "check_description",
 		"check_tag":   "check_tag_name",
-		// Kolide K2 supports filtering by check_tag_id and check_tag_description as well
+		// Kolide API supports filtering by check_tag_id and check_tag_description as well
 	}
 
 	return c.fetchCollection("/checks/", cursor, limit, searches, new(CheckListResponse), friendlies)

--- a/kolide/client/issues.go
+++ b/kolide/client/issues.go
@@ -25,12 +25,12 @@ type Issue struct {
 }
 
 type DeviceInformation struct {
-	// Whilst the Kolide K2 API readme entry references this as a "string", the returned value encountered in testing is an "int"
+	// Whilst the Kolide API readme entry references this as a "string", the returned value encountered in testing is an "int"
 	Identifier int32 `json:"identifier,omitempty"`
 }
 
 type CheckInformation struct {
-	// Whilst the Kolide K2 API readme entry references this as a "string", the returned value encountered in testing is an "int"
+	// Whilst the Kolide API readme entry references this as a "string", the returned value encountered in testing is an "int"
 	Identifier int32 `json:"identifier,omitempty"`
 }
 

--- a/kolide/connection_config.go
+++ b/kolide/connection_config.go
@@ -5,7 +5,7 @@ import (
 	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/schema"
 )
 
-type kolideK2Config struct {
+type kolideConfig struct {
 	APIToken *string `cty:"api_token"`
 }
 
@@ -16,13 +16,13 @@ var ConfigSchema = map[string]*schema.Attribute{
 }
 
 func ConfigInstance() interface{} {
-	return &kolideK2Config{}
+	return &kolideConfig{}
 }
 
-func GetConfig(connection *plugin.Connection) kolideK2Config {
+func GetConfig(connection *plugin.Connection) kolideConfig {
 	if connection == nil || connection.Config == nil {
-		return kolideK2Config{}
+		return kolideConfig{}
 	}
-	config, _ := connection.Config.(kolideK2Config)
+	config, _ := connection.Config.(kolideConfig)
 	return config
 }

--- a/kolide/plugin.go
+++ b/kolide/plugin.go
@@ -19,20 +19,20 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 			ShouldIgnoreErrorFunc: shouldIgnoreErrors([]string{"404"}),
 		},
 		DefaultRetryConfig: &plugin.RetryConfig{
-			// Preference would be to respect Retry-After header that Kolide K2 API supports
+			// Preference would be to respect `Retry-After` header that Kolide API supports
 			// For now, default to Fibonacci, ten retries starting at 100ms
 			ShouldRetryErrorFunc: shouldRetryError([]string{"429"}),
 		},
 
 		TableMap: map[string]*plugin.Table{
-			"kolide_k2_admin_user":           tableKolideK2AdminUser(ctx),
-			"kolide_k2_audit_log":            tableKolideK2AuditLog(ctx),
-			"kolide_k2_check":                tableKolideK2Check(ctx),
-			"kolide_k2_deprovisioned_person": tableKolideK2DeprovisionedPerson(ctx),
-			"kolide_k2_device":               tableKolideK2Device(ctx),
-			"kolide_k2_device_open_issue":    tableKolideK2DeviceOpenIssue(ctx),
-			"kolide_k2_issue":                tableKolideK2Issue(ctx),
-			"kolide_k2_package":              tableKolideK2Package(ctx),
+			"kolide_admin_user":           tableKolideAdminUser(ctx),
+			"kolide_audit_log":            tableKolideAuditLog(ctx),
+			"kolide_check":                tableKolideCheck(ctx),
+			"kolide_deprovisioned_person": tableKolideDeprovisionedPerson(ctx),
+			"kolide_device":               tableKolideDevice(ctx),
+			"kolide_device_open_issue":    tableKolideDeviceOpenIssue(ctx),
+			"kolide_issue":                tableKolideIssue(ctx),
+			"kolide_package":              tableKolidePackage(ctx),
 		},
 	}
 	return p

--- a/kolide/table_kolide_admin_user.go
+++ b/kolide/table_kolide_admin_user.go
@@ -11,9 +11,9 @@ import (
 
 //// TABLE DEFINITION
 
-func tableKolideK2AdminUser(_ context.Context) *plugin.Table {
+func tableKolideAdminUser(_ context.Context) *plugin.Table {
 	return &plugin.Table{
-		Name:        "kolide_k2_admin_user",
+		Name:        "kolide_admin_user",
 		Description: "Users with access to the Kolide dashboard.",
 		Columns: []*plugin.Column{
 			// Filterable "top" columns
@@ -30,7 +30,7 @@ func tableKolideK2AdminUser(_ context.Context) *plugin.Table {
 		},
 		List: &plugin.ListConfig{
 			KeyColumns: []*plugin.KeyColumn{
-				// Using Kolide K2 API query feature, can be combined with AND (and OR)
+				// Using Kolide API query feature, can be combined with AND (and OR)
 				{Name: "first_name", Require: plugin.Optional, Operators: []string{"=", "~~"}},
 				{Name: "last_name", Require: plugin.Optional, Operators: []string{"=", "~~"}},
 				{Name: "email", Require: plugin.Optional, Operators: []string{"=", "~~"}},
@@ -52,7 +52,7 @@ func listAdminUsers(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateD
 		return client.GetAdminUsers(cursor, limit, searches...)
 	}
 
-	return listAnything(ctx, d, h, "kolide_k2_admin_user.listAdminUsers", visitor, "AdminUsers")
+	return listAnything(ctx, d, h, "kolide_admin_user.listAdminUsers", visitor, "AdminUsers")
 }
 
 //// GET FUNCTION
@@ -62,5 +62,5 @@ func getAdminUser(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateDat
 		return client.GetAdminUserById(id)
 	}
 
-	return getAnything(ctx, d, h, "kolide_k2_admin_user.getAdminUser", "id", visitor)
+	return getAnything(ctx, d, h, "kolide_admin_user.getAdminUser", "id", visitor)
 }

--- a/kolide/table_kolide_audit_log.go
+++ b/kolide/table_kolide_audit_log.go
@@ -11,9 +11,9 @@ import (
 
 //// TABLE DEFINITION
 
-func tableKolideK2AuditLog(_ context.Context) *plugin.Table {
+func tableKolideAuditLog(_ context.Context) *plugin.Table {
 	return &plugin.Table{
-		Name:        "kolide_k2_audit_log",
+		Name:        "kolide_audit_log",
 		Description: "Tracked events occurring in the Kolide web console.",
 		Columns: []*plugin.Column{
 			// Filterable "top" columns
@@ -27,7 +27,7 @@ func tableKolideK2AuditLog(_ context.Context) *plugin.Table {
 		},
 		List: &plugin.ListConfig{
 			KeyColumns: []*plugin.KeyColumn{
-				// Using Kolide K2 API query feature, can be combined with AND (and OR)
+				// Using Kolide API query feature, can be combined with AND (and OR)
 				{Name: "timestamp", Require: plugin.Optional, Operators: []string{"=", ">", "<"}},
 				{Name: "actor_name", Require: plugin.Optional, Operators: []string{"=", "~~"}},
 				{Name: "description", Require: plugin.Optional, Operators: []string{"=", "~~"}},
@@ -48,7 +48,7 @@ func listAuditLogs(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateDa
 		return client.GetAuditLogs(cursor, limit, searches...)
 	}
 
-	return listAnything(ctx, d, h, "kolide_k2_audit_log.listAuditLogs", visitor, "AuditLogs")
+	return listAnything(ctx, d, h, "kolide_audit_log.listAuditLogs", visitor, "AuditLogs")
 }
 
 //// GET FUNCTION
@@ -58,5 +58,5 @@ func getAuditLog(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData
 		return client.GetAuditLogById(id)
 	}
 
-	return getAnything(ctx, d, h, "kolide_k2_audit_log.getAuditLog", "id", visitor)
+	return getAnything(ctx, d, h, "kolide_audit_log.getAuditLog", "id", visitor)
 }

--- a/kolide/table_kolide_check.go
+++ b/kolide/table_kolide_check.go
@@ -11,9 +11,9 @@ import (
 
 //// TABLE DEFINITION
 
-func tableKolideK2Check(_ context.Context) *plugin.Table {
+func tableKolideCheck(_ context.Context) *plugin.Table {
 	return &plugin.Table{
-		Name:        "kolide_k2_check",
+		Name:        "kolide_check",
 		Description: "Checks that Kolide runs on a device on a regular cadence, which are tests that typically produces a passing or failing result.",
 		Columns: []*plugin.Column{
 			// Filterable "top" columns
@@ -35,7 +35,7 @@ func tableKolideK2Check(_ context.Context) *plugin.Table {
 		},
 		List: &plugin.ListConfig{
 			KeyColumns: []*plugin.KeyColumn{
-				// Using Kolide K2 API query feature, can be combined with AND (and OR)
+				// Using Kolide API query feature, can be combined with AND (and OR)
 				{Name: "name", Require: plugin.Optional, Operators: []string{"=", "~~"}},
 				{Name: "description", Require: plugin.Optional, Operators: []string{"=", "~~"}},
 				{Name: "check_tags", Require: plugin.Optional, Operators: []string{"=", "~~"}},
@@ -56,7 +56,7 @@ func listChecks(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData)
 		return client.GetChecks(cursor, limit, searches...)
 	}
 
-	return listAnything(ctx, d, h, "kolide_k2_audit_log.listChecks", visitor, "Checks")
+	return listAnything(ctx, d, h, "kolide_check.listChecks", visitor, "Checks")
 }
 
 //// GET FUNCTION
@@ -66,5 +66,5 @@ func getCheck(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (
 		return client.GetCheckById(id)
 	}
 
-	return getAnything(ctx, d, h, "kolide_k2_audit_log.getCheck", "id", visitor)
+	return getAnything(ctx, d, h, "kolide_check.getCheck", "id", visitor)
 }

--- a/kolide/table_kolide_deprovisioned_person.go
+++ b/kolide/table_kolide_deprovisioned_person.go
@@ -11,9 +11,9 @@ import (
 
 //// TABLE DEFINITION
 
-func tableKolideK2DeprovisionedPerson(_ context.Context) *plugin.Table {
+func tableKolideDeprovisionedPerson(_ context.Context) *plugin.Table {
 	return &plugin.Table{
-		Name:        "kolide_k2_deprovisioned_person",
+		Name:        "kolide_deprovisioned_person",
 		Description: "Anyone who has been removed from Kolide via SCIM.",
 		Columns: []*plugin.Column{
 			// Filterable "top" columns
@@ -29,7 +29,7 @@ func tableKolideK2DeprovisionedPerson(_ context.Context) *plugin.Table {
 		},
 		List: &plugin.ListConfig{
 			KeyColumns: []*plugin.KeyColumn{
-				// Using Kolide K2 API query feature, can be combined with AND (and OR)
+				// Using Kolide API query feature, can be combined with AND (and OR)
 				{Name: "name", Require: plugin.Optional, Operators: []string{"=", "~~"}},
 				{Name: "email", Require: plugin.Optional, Operators: []string{"=", "~~"}},
 				{Name: "last_authenticated_at", Require: plugin.Optional, Operators: []string{"=", ">", "<"}},
@@ -46,5 +46,5 @@ func listDeprovisionedPeople(ctx context.Context, d *plugin.QueryData, h *plugin
 		return client.GetDeprovisionedPeople(cursor, limit, searches...)
 	}
 
-	return listAnything(ctx, d, h, "kolide_k2_deprovisioned_person.listDeprovisionedPeople", visitor, "DeprovisionedPeople")
+	return listAnything(ctx, d, h, "kolide_deprovisioned_person.listDeprovisionedPeople", visitor, "DeprovisionedPeople")
 }

--- a/kolide/table_kolide_device.go
+++ b/kolide/table_kolide_device.go
@@ -11,9 +11,9 @@ import (
 
 //// TABLE DEFINITION
 
-func tableKolideK2Device(_ context.Context) *plugin.Table {
+func tableKolideDevice(_ context.Context) *plugin.Table {
 	return &plugin.Table{
-		Name:        "kolide_k2_device",
+		Name:        "kolide_device",
 		Description: "Devices enrolled and monitored by Kolide.",
 		Columns: []*plugin.Column{
 			// Filterable "top" columns
@@ -41,7 +41,7 @@ func tableKolideK2Device(_ context.Context) *plugin.Table {
 		},
 		List: &plugin.ListConfig{
 			KeyColumns: []*plugin.KeyColumn{
-				// Using Kolide K2 API query feature, can be combined with AND (and OR)
+				// Using Kolide API query feature, can be combined with AND (and OR)
 				{Name: "name", Require: plugin.Optional, Operators: []string{"=", "~~"}},
 				{Name: "registered_at", Require: plugin.Optional, Operators: []string{"=", ">", "<"}},
 				{Name: "last_authenticated_at", Require: plugin.Optional, Operators: []string{"=", ">", "<"}},
@@ -67,7 +67,7 @@ func listDevices(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData
 		return client.GetDevices(cursor, limit, searches...)
 	}
 
-	return listAnything(ctx, d, h, "kolide_k2_device.listDevices", visitor, "Devices")
+	return listAnything(ctx, d, h, "kolide_device.listDevices", visitor, "Devices")
 }
 
 //// GET FUNCTION
@@ -77,5 +77,5 @@ func getDevice(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) 
 		return client.GetDeviceById(id)
 	}
 
-	return getAnything(ctx, d, h, "kolide_k2_device.getDevice", "id", visitor)
+	return getAnything(ctx, d, h, "kolide_device.getDevice", "id", visitor)
 }

--- a/kolide/table_kolide_device_open_issues.go
+++ b/kolide/table_kolide_device_open_issues.go
@@ -11,9 +11,9 @@ import (
 
 //// TABLE DEFINITION
 
-func tableKolideK2DeviceOpenIssue(_ context.Context) *plugin.Table {
+func tableKolideDeviceOpenIssue(_ context.Context) *plugin.Table {
 	return &plugin.Table{
-		Name:        "kolide_k2_device_open_issue",
+		Name:        "kolide_device_open_issue",
 		Description: "Unresolved and non-exempt issues created when a specific device fails a check; some checks, when they fail, will produce multiple Issues, each with a unique primary_key_value.",
 		Columns: []*plugin.Column{
 			// Filterable "top" columns
@@ -31,12 +31,12 @@ func tableKolideK2DeviceOpenIssue(_ context.Context) *plugin.Table {
 			// Other columns
 			{Name: "value", Description: "Relevant data that describes why the device failed the check.", Type: proto.ColumnType_JSON},
 			// Steampipe standard columns
-			// - We include "title" above as an expected Kolide K2 API column, and it is sufficient
+			// - We include "title" above as an expected Kolide API column, and it is sufficient
 		},
 		List: &plugin.ListConfig{
 			KeyColumns: []*plugin.KeyColumn{
 				{Name: "device_id", Require: plugin.Required, Operators: []string{"="}},
-				// Using Kolide K2 API query feature, can be combined with AND (and OR)
+				// Using Kolide API query feature, can be combined with AND (and OR)
 				{Name: "issue_key", Require: plugin.Optional, Operators: []string{"=", "~~"}},
 				{Name: "issue_value", Require: plugin.Optional, Operators: []string{"=", "~~"}},
 				{Name: "title", Require: plugin.Optional, Operators: []string{"=", "~~"}},
@@ -59,5 +59,5 @@ func listIssuesByDevice(ctx context.Context, d *plugin.QueryData, h *plugin.Hydr
 		return client.GetIssuesByDevice(id, cursor, limit, searches...)
 	}
 
-	return listAnythingById(ctx, d, h, "kolide_k2_issue.listIssuesByDevice", "device_id", visitor, "Issues")
+	return listAnythingById(ctx, d, h, "kolide_device_open_issue.listIssuesByDevice", "device_id", visitor, "Issues")
 }

--- a/kolide/table_kolide_issue.go
+++ b/kolide/table_kolide_issue.go
@@ -11,9 +11,9 @@ import (
 
 //// TABLE DEFINITION
 
-func tableKolideK2Issue(_ context.Context) *plugin.Table {
+func tableKolideIssue(_ context.Context) *plugin.Table {
 	return &plugin.Table{
-		Name:        "kolide_k2_issue",
+		Name:        "kolide_issue",
 		Description: "Issues created when a device fails a check; some checks, when they fail, will produce multiple Issues, each with a unique primary_key_value.",
 		Columns: []*plugin.Column{
 			// Filterable "top" columns
@@ -31,11 +31,11 @@ func tableKolideK2Issue(_ context.Context) *plugin.Table {
 			// Other columns
 			{Name: "value", Description: "Relevant data that describes why the device failed the check.", Type: proto.ColumnType_JSON},
 			// Steampipe standard columns
-			// - We include "title" above as an expected Kolide K2 API column, and it is sufficient
+			// - We include "title" above as an expected Kolide API column, and it is sufficient
 		},
 		List: &plugin.ListConfig{
 			KeyColumns: []*plugin.KeyColumn{
-				// Using Kolide K2 API query feature, can be combined with AND (and OR)
+				// Using Kolide API query feature, can be combined with AND (and OR)
 				{Name: "issue_key", Require: plugin.Optional, Operators: []string{"=", "~~"}},
 				{Name: "issue_value", Require: plugin.Optional, Operators: []string{"=", "~~"}},
 				{Name: "title", Require: plugin.Optional, Operators: []string{"=", "~~"}},
@@ -63,7 +63,7 @@ func listIssues(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData)
 		return client.GetIssues(cursor, limit, searches...)
 	}
 
-	return listAnything(ctx, d, h, "kolide_k2_issue.listIssues", visitor, "Issues")
+	return listAnything(ctx, d, h, "kolide_issue.listIssues", visitor, "Issues")
 }
 
 //// GET FUNCTION
@@ -73,5 +73,5 @@ func getIssue(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (
 		return client.GetIssueById(id)
 	}
 
-	return getAnything(ctx, d, h, "kolide_k2_issue.getIssue", "id", visitor)
+	return getAnything(ctx, d, h, "kolide_issue.getIssue", "id", visitor)
 }

--- a/kolide/table_kolide_package.go
+++ b/kolide/table_kolide_package.go
@@ -11,16 +11,16 @@ import (
 
 //// TABLE DEFINITION
 
-func tableKolideK2Package(_ context.Context) *plugin.Table {
+func tableKolidePackage(_ context.Context) *plugin.Table {
 	return &plugin.Table{
-		Name:        "kolide_k2_package",
+		Name:        "kolide_package",
 		Description: "Installation packages for Kolide Launcher agent for each major operating system.",
 		Columns: []*plugin.Column{
 			// Filterable "top" columns
 			{Name: "id", Description: "Unique identifier for this package.", Type: proto.ColumnType_STRING},
 			// Other columns
 			{Name: "built_at", Description: "When this installation package was built.", Type: proto.ColumnType_TIMESTAMP},
-			{Name: "url", Description: "URL that can be used to download this installation package. Requests to this url require the standard Authorization header needed for all Kolide K2 API requests.", Type: proto.ColumnType_STRING},
+			{Name: "url", Description: "URL that can be used to download this installation package. Requests to this url require the standard Authorization header needed for all Kolide API requests.", Type: proto.ColumnType_STRING},
 			{Name: "version", Description: "Version of the Launcher agent that will be installed by this package.", Type: proto.ColumnType_STRING},
 			// Steampipe standard columns
 			{Name: "title", Description: "Display name for this event.", Type: proto.ColumnType_STRING, Transform: transform.FromField("Id")},
@@ -42,7 +42,7 @@ func listPackages(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateDat
 		return client.GetPackages(cursor, limit, searches...)
 	}
 
-	return listAnything(ctx, d, h, "kolide_k2_audit_log.listPackages", visitor, "Packages")
+	return listAnything(ctx, d, h, "kolide_package.listPackages", visitor, "Packages")
 }
 
 //// GET FUNCTION
@@ -52,5 +52,5 @@ func getPackage(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData)
 		return client.GetPackageById(id)
 	}
 
-	return getAnything(ctx, d, h, "kolide_k2_audit_log.getPackage", "id", visitor)
+	return getAnything(ctx, d, h, "kolide_package.getPackage", "id", visitor)
 }

--- a/kolide/utils.go
+++ b/kolide/utils.go
@@ -27,7 +27,7 @@ func connect(ctx context.Context, d *plugin.QueryData) (*kolide.Client, error) {
 	}
 
 	if api_token == "" {
-		return nil, errors.New("kolide k2 'api_token' must be set in the connection configuration; edit your connection configuration file and then restart")
+		return nil, errors.New("kolide 'api_token' must be set in the connection configuration; edit your connection configuration file and then restart")
 	}
 
 	c := kolide.New(
@@ -214,7 +214,7 @@ func query(ctx context.Context, d *plugin.QueryData) ([]kolide.Search, error) {
 	return searches, nil
 }
 
-// Operators supported by Kolide K2 API are:
+// Operators supported by Kolide API are:
 //
 // - Exact match, ":"
 // - Substring match, "~", treated as Like


### PR DESCRIPTION
## Description

Renamed tables to omit "K2" since that was proving to be a source of confusion

## Related Tickets & Documents

Relates to #59 

## Steps to Verify

Execute all example SQL queries without issue