### PR TITLE
chore(docs): errant K2 in documentation

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -79,7 +79,7 @@ connection "kolide" {
 Alternatively, and **only if the `api_token` is omitted** in the connections, you can use the  Kolide environment variable to obtain credentials only if api_token is not specified in the connection:
 
 ```zsh
-export KOLIDE_K2_TOKEN=k2sk_v1_thisIsOurExampleKey
+export KOLIDE_API_TOKEN=k2sk_v1_thisIsOurExampleKey
 ```
 
 ### Rate Limiting


### PR DESCRIPTION
## Description

Erroneous "K2" spotted in documentation

## Related Tickets & Documents

None

## Steps to Verify

Re-searching the repo for "K2"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the environment variable naming from `KOLIDE_K2_TOKEN` to `KOLIDE_API_TOKEN` in the documentation to align with current configuration practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->