### PR TITLE
feat: implement GET /people/ and /people/{id}

### DIFF
--- a/docs/tables/kolide_person.md
+++ b/docs/tables/kolide_person.md
@@ -1,0 +1,40 @@
+# Table: kolide_person
+
+Lists the people within your organisation, who may not necessarily have access to the Kolide dashboard (see kolide_admin_user). Devices may be registered to a person
+
+## Examples
+
+### Basic info
+
+```sql
+select
+  id,
+  name,
+  email,
+  has_registered_device
+from
+  kolide_person;
+```
+
+### Find me which people have not been authorised recently
+
+```sql
+select
+  name,
+  last_authenticated_at
+from
+  kolide_person
+where
+  last_authenticated_at <> date_trunc('day', current_date) - interval '4 weeks';
+```
+
+### Find me which people have no devices
+
+```sql
+select
+  name
+from
+  kolide_person
+where
+  has_registered_device = false
+```

--- a/kolide/client/people.go
+++ b/kolide/client/people.go
@@ -1,0 +1,27 @@
+package kolide_client
+
+import (
+	"time"
+)
+
+type PeopleListResponse struct {
+	People     []Person   `json:"data"`
+	Pagination Pagination `json:"pagination"`
+}
+type Person struct {
+	Id                  string    `json:"id"`
+	Name                string    `json:"name"`
+	Email               string    `json:"email"`
+	CreatedAt           time.Time `json:"created_at"`
+	LastAuthenticatedAt time.Time `json:"last_authenticated_at"`
+	HasRegisteredDevice bool      `json:"has_registered_device"`
+	Usernames           []int     `json:"uernames"`
+}
+
+func (c *Client) GetPeople(cursor string, limit int32, searches ...Search) (interface{}, error) {
+	return c.fetchCollection("/people/", cursor, limit, searches, new(PeopleListResponse))
+}
+
+func (c *Client) GetPersonById(id string) (interface{}, error) {
+	return c.fetchResource("/people/", id, new(Person))
+}

--- a/kolide/client/people.go
+++ b/kolide/client/people.go
@@ -15,7 +15,7 @@ type Person struct {
 	CreatedAt           time.Time `json:"created_at"`
 	LastAuthenticatedAt time.Time `json:"last_authenticated_at"`
 	HasRegisteredDevice bool      `json:"has_registered_device"`
-	Usernames           []int     `json:"uernames"`
+	Usernames           []int     `json:"usernames"`
 }
 
 func (c *Client) GetPeople(cursor string, limit int32, searches ...Search) (interface{}, error) {

--- a/kolide/plugin.go
+++ b/kolide/plugin.go
@@ -33,6 +33,7 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 			"kolide_device_open_issue":    tableKolideDeviceOpenIssue(ctx),
 			"kolide_issue":                tableKolideIssue(ctx),
 			"kolide_package":              tableKolidePackage(ctx),
+			"kolide_person":               tableKolidePerson(ctx),
 		},
 	}
 	return p

--- a/kolide/table_kolide_person.go
+++ b/kolide/table_kolide_person.go
@@ -1,0 +1,65 @@
+package kolide
+
+import (
+	"context"
+
+	kolide "github.com/grendel-consulting/steampipe-plugin-kolide/kolide/client"
+	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+)
+
+//// TABLE DEFINITION
+
+func tableKolidePerson(_ context.Context) *plugin.Table {
+	return &plugin.Table{
+		Name:        "kolide_person",
+		Description: "People within your organisation, who may not necessarily have access to the Kolide dashboard (see kolide_admin_user). Devices may be registered to a person",
+		Columns: []*plugin.Column{
+			// Filterable "top" columns
+			{Name: "id", Description: "Unique identifier for this person.", Type: proto.ColumnType_STRING},
+			{Name: "name", Description: "Human-readable name for this person.", Type: proto.ColumnType_STRING},
+			{Name: "email", Description: "Recorded email addresss for this person.", Type: proto.ColumnType_STRING},
+			{Name: "last_authenticated_at", Description: "When this person last authenticated with Kolide.", Type: proto.ColumnType_TIMESTAMP},
+			// Other columns
+			{Name: "created_at", Description: "When this person record was created.", Type: proto.ColumnType_TIMESTAMP},
+			{Name: "has_registered_device", Description: "Whether or not this person has at least one reigstered device.", Type: proto.ColumnType_BOOL},
+			{Name: "usernames", Description: "Any usernames imported from the SCIM provider associated with this person.", Type: proto.ColumnType_JSON},
+			// Steampipe standard columns
+			{Name: "title", Description: "Display name for this person.", Type: proto.ColumnType_STRING, Transform: transform.FromField("Name")},
+		},
+		List: &plugin.ListConfig{
+			KeyColumns: []*plugin.KeyColumn{
+				// Using Kolide API query feature, can be combined with AND (and OR)
+				{Name: "name", Require: plugin.Optional, Operators: []string{"=", "~~"}},
+				{Name: "email", Require: plugin.Optional, Operators: []string{"=", "~~"}},
+				{Name: "last_authenticated_at", Require: plugin.Optional, Operators: []string{"=", ">", "<"}},
+			},
+			Hydrate: listPeople,
+		},
+		Get: &plugin.GetConfig{
+			KeyColumns: plugin.SingleColumn("id"),
+			Hydrate:    getPerson,
+		},
+	}
+}
+
+//// LIST FUNCTION
+
+func listPeople(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	var visitor ListPredicate = func(client *kolide.Client, cursor string, limit int32, searches ...kolide.Search) (interface{}, error) {
+		return client.GetPackages(cursor, limit, searches...)
+	}
+
+	return listAnything(ctx, d, h, "kolide_person.listPeople", visitor, "Person")
+}
+
+//// GET FUNCTION
+
+func getPerson(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	var visitor GetPredicate = func(client *kolide.Client, id string) (interface{}, error) {
+		return client.GetPersonById(id)
+	}
+
+	return getAnything(ctx, d, h, "kolide_person.getPerson", "id", visitor)
+}


### PR DESCRIPTION
## Description

Aims to implement the GET /people/ and /people/{id} endpoints

Untested with real results, since my current Kolide plan has no entries for this table

## Related Tickets & Documents

Closes #12 , #24 

## Steps to Verify

Execute the queries in the documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced the Kolide client with functionality to manage people, including their IDs, names, emails, registration status, and authentication details.

- **Documentation**
	- Updated documentation to include details on managing people within the organization using the `kolide_person` table.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->