### PR TITLE
feat: implement GET /person_groups/ and /person_groups/{id}

### DIFF
--- a/docs/tables/kolide_person_group.md
+++ b/docs/tables/kolide_person_group.md
@@ -1,0 +1,15 @@
+# Table: kolide_person_group
+
+Lists the groups of people within your organisation, synced from your SCIM provider.
+
+## Examples
+
+### Basic info
+
+```sql
+select
+  id,
+  name
+from
+  kolide_person_group;
+```

--- a/kolide/client/devices.go
+++ b/kolide/client/devices.go
@@ -36,11 +36,6 @@ type AuthConfiguration struct {
 	PersonGroups       []PersonGroup `json:"person_groups"`
 }
 
-type PersonGroup struct {
-	Id   string `json:"id"`
-	Name string `json:"name"`
-}
-
 func (c *Client) GetDevices(cursor string, limit int32, searches ...Search) (interface{}, error) {
 	return c.fetchCollection("/devices/", cursor, limit, searches, new(DeviceListResponse))
 }

--- a/kolide/client/person_groups.go
+++ b/kolide/client/person_groups.go
@@ -1,0 +1,18 @@
+package kolide_client
+
+type PersonGroupListResponse struct {
+	PersonGroups []PersonGroup `json:"data"`
+	Pagination   Pagination    `json:"pagination"`
+}
+type PersonGroup struct {
+	Id   string `json:"id"`
+	Name string `json:"name"`
+}
+
+func (c *Client) GetPersonGroups(cursor string, limit int32, searches ...Search) (interface{}, error) {
+	return c.fetchCollection("/person_groups/", cursor, limit, searches, new(PersonGroupListResponse))
+}
+
+func (c *Client) GetPersonGroupById(id string) (interface{}, error) {
+	return c.fetchResource("/person_groups/", id, new(PersonGroup))
+}

--- a/kolide/plugin.go
+++ b/kolide/plugin.go
@@ -34,6 +34,7 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 			"kolide_issue":                tableKolideIssue(ctx),
 			"kolide_package":              tableKolidePackage(ctx),
 			"kolide_person":               tableKolidePerson(ctx),
+			"kolide_person_group":         tableKolidePersonGroup(ctx),
 		},
 	}
 	return p

--- a/kolide/table_kolide_person_group.go
+++ b/kolide/table_kolide_person_group.go
@@ -1,0 +1,58 @@
+package kolide
+
+import (
+	"context"
+
+	kolide "github.com/grendel-consulting/steampipe-plugin-kolide/kolide/client"
+	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+)
+
+//// TABLE DEFINITION
+
+func tableKolidePersonGroup(_ context.Context) *plugin.Table {
+	return &plugin.Table{
+		Name:        "kolide_person_group",
+		Description: "Group of people, these are synced from your SCIM provider",
+		Columns: []*plugin.Column{
+			// Filterable "top" columns
+			{Name: "id", Description: "Canonical identifier for this group.", Type: proto.ColumnType_STRING},
+			{Name: "name", Description: "Human-readable name for this group.", Type: proto.ColumnType_STRING},
+			// Other columns
+			// Steampipe standard columns
+			{Name: "title", Description: "Display name for this group.", Type: proto.ColumnType_STRING, Transform: transform.FromField("Name")},
+		},
+		List: &plugin.ListConfig{
+			KeyColumns: []*plugin.KeyColumn{
+				// Using Kolide API query feature, can be combined with AND (and OR)
+				{Name: "name", Require: plugin.Optional, Operators: []string{"=", "~~"}},
+			},
+			Hydrate: listPersonGroups,
+		},
+		Get: &plugin.GetConfig{
+			KeyColumns: plugin.SingleColumn("id"),
+			Hydrate:    getPersonGroup,
+		},
+	}
+}
+
+//// LIST FUNCTION
+
+func listPersonGroups(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	var visitor ListPredicate = func(client *kolide.Client, cursor string, limit int32, searches ...kolide.Search) (interface{}, error) {
+		return client.GetPersonGroups(cursor, limit, searches...)
+	}
+
+	return listAnything(ctx, d, h, "kolide_person_group.listPersonGroups", visitor, "PersonGroup")
+}
+
+//// GET FUNCTION
+
+func getPersonGroup(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	var visitor GetPredicate = func(client *kolide.Client, id string) (interface{}, error) {
+		return client.GetPersonGroupById(id)
+	}
+
+	return getAnything(ctx, d, h, "kolide_person_group.getPersonGroup", "id", visitor)
+}


### PR DESCRIPTION
## Description

Implements GET /person_groups/ and /person_groups/{id} endpoints

## Related Tickets & Documents

closes #25 , closes #26 

## Steps to Verify

Untested, 403

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced management functionality for person groups within the Kolide client API.
  - Added a new table `kolide_person_group` to display groups of people synced from a SCIM provider.

- **Refactor**
  - Removed `PersonGroup` struct and merged its fields into `AuthConfiguration`.

- **Documentation**
  - Added documentation for the new `kolide_person_group` table.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->