### PR TITLE
feat: implement GET /device_groups/, /device_groups/{id}, and /device_groups/{id}/devices

### DIFF
--- a/docs/tables/kolide_device_group.md
+++ b/docs/tables/kolide_device_group.md
@@ -1,0 +1,39 @@
+# Table: kolide_device_group
+
+Lists the groups of devices within your organisation, created by you.
+
+## Examples
+
+### Basic info
+
+```sql
+select
+  id,
+  name
+from
+  kolide_device_group;
+```
+
+### Find any empty of unused device groups
+
+```sql
+select
+  id,
+  name
+from
+  kolide_device_group;
+where
+  member_count = 0;
+```
+
+### Find any newly created device groups
+
+```sql
+select
+  id,
+  name
+from
+  kolide_device_group;
+where
+  created_at > date_trunc('day', current_date) - interval '1 week';
+```

--- a/docs/tables/kolide_device_group_device.md
+++ b/docs/tables/kolide_device_group_device.md
@@ -1,0 +1,35 @@
+# Table: kolide_device_group_device
+
+Lists the member devices within a device group.
+
+You will need to provide a valid `device_group_id` for all queries to this table.
+
+## Examples
+
+### Basic info
+
+```sql
+select
+  name,
+  hardware_model,
+  serial
+from
+  kolide_device_group_device
+where
+  device_group_id = '12345';
+```
+
+### List the devices in this device group whose users have been notified of resolvable issues
+
+```sql
+select
+  name,
+  hardware_model,
+  serial
+from
+  kolide_device_group_device
+where
+  device_group_id = '12345'
+  and
+  auth_state = 'Notified';
+```

--- a/kolide/client/device_groups.go
+++ b/kolide/client/device_groups.go
@@ -1,0 +1,29 @@
+package kolide_client
+
+import (
+	"time"
+)
+
+type DeviceGroupListResponse struct {
+	DeviceGroups []DeviceGroup `json:"data"`
+	Pagination   Pagination    `json:"pagination"`
+}
+type DeviceGroup struct {
+	Id           string    `json:"id"`
+	Name         string    `json:"name"`
+	CreatedAt    time.Time `json:"created_at,omitempty"`
+	Description  string    `json:"description,omitempty"`
+	MembersCount int       `json:"members_count"`
+}
+
+func (c *Client) GetDeviceGroups(cursor string, limit int32, searches ...Search) (interface{}, error) {
+	return c.fetchCollection("/device_groups/", cursor, limit, searches, new(DeviceGroupListResponse))
+}
+
+func (c *Client) GetDeviceGroupById(id string) (interface{}, error) {
+	return c.fetchResource("/device_groups/", id, new(DeviceGroup))
+}
+
+func (c *Client) GetDevicesByDeviceGroup(id string, cursor string, limit int32, searches ...Search) (interface{}, error) {
+	return c.fetchCollectionWithResourceId("/device_groups/{resourceId}/devices", id, cursor, limit, searches, new(DeviceListResponse))
+}

--- a/kolide/plugin.go
+++ b/kolide/plugin.go
@@ -30,6 +30,8 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 			"kolide_check":                tableKolideCheck(ctx),
 			"kolide_deprovisioned_person": tableKolideDeprovisionedPerson(ctx),
 			"kolide_device":               tableKolideDevice(ctx),
+			"kolide_device_group":         tableKolideDeviceGroup(ctx),
+			"kolide_device_group_device":  tableKolideDeviceGroupDevice(ctx),
 			"kolide_device_open_issue":    tableKolideDeviceOpenIssue(ctx),
 			"kolide_issue":                tableKolideIssue(ctx),
 			"kolide_package":              tableKolidePackage(ctx),

--- a/kolide/table_kolide_device_group.go
+++ b/kolide/table_kolide_device_group.go
@@ -1,0 +1,63 @@
+package kolide
+
+import (
+	"context"
+
+	kolide "github.com/grendel-consulting/steampipe-plugin-kolide/kolide/client"
+	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+)
+
+//// TABLE DEFINITION
+
+func tableKolideDeviceGroup(_ context.Context) *plugin.Table {
+	return &plugin.Table{
+		Name:        "kolide_device_group",
+		Description: "Group of devices, created in the UI or API",
+		Columns: []*plugin.Column{
+			// Filterable "top" columns
+			{Name: "id", Description: "Canonical identifier for this group.", Type: proto.ColumnType_STRING},
+			{Name: "name", Description: "Human-readable name for this group.", Type: proto.ColumnType_STRING},
+			{Name: "created_at", Description: "When this group record was created.", Type: proto.ColumnType_TIMESTAMP},
+			{Name: "description", Description: "Longer-form description about this device group.", Type: proto.ColumnType_STRING},
+			// Other columns
+			{Name: "member_count", Description: "Number of member devices in this group.", Type: proto.ColumnType_INT},
+			// Steampipe standard columns
+			{Name: "title", Description: "Display name for this group.", Type: proto.ColumnType_STRING, Transform: transform.FromField("Name")},
+		},
+		List: &plugin.ListConfig{
+			KeyColumns: []*plugin.KeyColumn{
+				// Using Kolide API query feature, can be combined with AND (and OR)
+				{Name: "name", Require: plugin.Optional, Operators: []string{"=", "~~"}},
+				{Name: "created_at", Require: plugin.Optional, Operators: []string{"=", ">", "<"}},
+				{Name: "description", Require: plugin.Optional, Operators: []string{"=", "~~"}},
+			},
+			Hydrate: listDeviceGroups,
+		},
+		Get: &plugin.GetConfig{
+			KeyColumns: plugin.SingleColumn("id"),
+			Hydrate:    getDeviceGroup,
+		},
+	}
+}
+
+//// LIST FUNCTION
+
+func listDeviceGroups(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	var visitor ListPredicate = func(client *kolide.Client, cursor string, limit int32, searches ...kolide.Search) (interface{}, error) {
+		return client.GetDeviceGroups(cursor, limit, searches...)
+	}
+
+	return listAnything(ctx, d, h, "kolide_device_group.listDeviceGroups", visitor, "DeviceGroup")
+}
+
+//// GET FUNCTION
+
+func getDeviceGroup(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	var visitor GetPredicate = func(client *kolide.Client, id string) (interface{}, error) {
+		return client.GetDeviceGroupById(id)
+	}
+
+	return getAnything(ctx, d, h, "kolide_device_group.getDeviceGroup", "id", visitor)
+}

--- a/kolide/table_kolide_device_group_device.go
+++ b/kolide/table_kolide_device_group_device.go
@@ -1,0 +1,68 @@
+package kolide
+
+import (
+	"context"
+
+	kolide "github.com/grendel-consulting/steampipe-plugin-kolide/kolide/client"
+	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+)
+
+//// TABLE DEFINITION
+
+func tableKolideDeviceGroupDevice(_ context.Context) *plugin.Table {
+	return &plugin.Table{
+		Name:        "kolide_device_group_device",
+		Description: "Member devices within a device group.",
+		Columns: []*plugin.Column{
+			// Filterable "top" columns
+			{Name: "device_group_id", Description: "Canonical identifier for the device.", Type: proto.ColumnType_STRING},
+			{Name: "name", Description: "Canonical human name for the device.", Type: proto.ColumnType_STRING},
+			{Name: "registered_at", Description: "When the device was registered to its current owner.", Type: proto.ColumnType_TIMESTAMP},
+			{Name: "last_authenticated_at", Description: "When the device was last authenticated with Kolide.", Type: proto.ColumnType_TIMESTAMP},
+			{Name: "serial", Description: "Hardware serial for the device.", Type: proto.ColumnType_STRING},
+			{Name: "hardware_uuid", Description: "Hardware UUID for the device.", Type: proto.ColumnType_STRING},
+			{Name: "note", Description: "Notes provided by a Kolide administrator (in Markdown format).", Type: proto.ColumnType_STRING},
+			{Name: "will_block_at", Description: "If the auth status is 'Will Block', this timestamp describes when the device will be blocked by a failing check.", Type: proto.ColumnType_TIMESTAMP},
+			{Name: "device_type", Description: "Platform type of the device, one of Mac, Windows, Linux, iOS or Android.", Type: proto.ColumnType_STRING},
+			// Other columns
+			{Name: "registered_owner_identifier", Description: "Canonical identifier for the registered owner of this device.", Type: proto.ColumnType_STRING},
+			{Name: "operating_system", Description: "Operating system installed on the device.", Type: proto.ColumnType_STRING},
+			{Name: "hardware_model", Description: "Specific hardware model of the device.", Type: proto.ColumnType_STRING},
+			{Name: "auth_state", Description: "Authorisation status of the device, one of Good, Notified, Will Block or Blocked.", Type: proto.ColumnType_STRING},
+			{Name: "product_image_url", Description: "URL of the device's product image.", Type: proto.ColumnType_STRING},
+			{Name: "auth_configuration_device_id", Description: "Canonical identifier for this device, empty if it is not registered", Type: proto.ColumnType_STRING},
+			{Name: "auth_configuration_authentication_mode", Description: "Who can be authenticated with this device, one of 'only_registered_owner', 'only_registered_owner_or_group_members' or 'anyone'.", Type: proto.ColumnType_STRING},
+			{Name: "auth_configuration_person_groups", Description: "Description of the groups allowed to authenticate with this device.", Type: proto.ColumnType_JSON},
+			{Name: "form_factor", Description: "Form factor of the device, one of Computer, Tablet or Phone.", Type: proto.ColumnType_STRING},
+			// Steampipe standard columns
+			{Name: "title", Description: "Display name for this resource.", Type: proto.ColumnType_STRING, Transform: transform.FromField("Name")},
+		},
+		List: &plugin.ListConfig{
+			KeyColumns: []*plugin.KeyColumn{
+				{Name: "device_group_id", Require: plugin.Required, Operators: []string{"="}},
+				// Using Kolide API query feature, can be combined with AND (and OR)
+				{Name: "name", Require: plugin.Optional, Operators: []string{"=", "~~"}},
+				{Name: "registered_at", Require: plugin.Optional, Operators: []string{"=", ">", "<"}},
+				{Name: "last_authenticated_at", Require: plugin.Optional, Operators: []string{"=", ">", "<"}},
+				{Name: "serial", Require: plugin.Optional, Operators: []string{"=", "~~"}},
+				{Name: "note", Require: plugin.Optional, Operators: []string{"=", "~~"}},
+				{Name: "hardware_uuid", Require: plugin.Optional, Operators: []string{"=", "~~"}},
+				{Name: "device_type", Require: plugin.Optional, Operators: []string{"=", "~~"}},
+				{Name: "will_block_at", Require: plugin.Optional, Operators: []string{"=", ">", "<"}},
+			},
+			Hydrate: listDevicesByDeviceGroup,
+		},
+	}
+}
+
+//// LIST FUNCTION
+
+func listDevicesByDeviceGroup(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	var visitor ListByIdPredicate = func(client *kolide.Client, id string, cursor string, limit int32, searches ...kolide.Search) (interface{}, error) {
+		return client.GetDevicesByDeviceGroup(id, cursor, limit, searches...)
+	}
+
+	return listAnythingById(ctx, d, h, "kolide_device_group_device.listDevicesByDeviceGroup", "device_group_id", visitor, "Device")
+}


### PR DESCRIPTION
## Description

Implement GET /device_groups/, /device_groups/{id}, and /device_groups/{id}/devices endpoints

## Related Tickets & Documents

closes #29 , closes #30, closes #31 

## Steps to Verify

Untested, 403

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced documentation and functionality for managing device groups and their member devices in the Kolide system.
	- Added new tables to list groups of devices and the devices within those groups, enhancing user ability to organize and query device information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->