### PR TITLE
fix: unmarshall registered owner info correctly

### DIFF
--- a/kolide/client/devices.go
+++ b/kolide/client/devices.go
@@ -9,21 +9,22 @@ type DeviceListResponse struct {
 	Pagination Pagination `json:"pagination"`
 }
 type Device struct {
-	Id                  string          `json:"id"`
-	Name                string          `json:"name"`
-	RegisteredAt        time.Time       `json:"registered_at,omitempty"`
-	LastAuthenticatedAt time.Time       `json:"last_authenticated_at,omitempty"`
-	RegisteredOwnerInfo RegisteredOwner `json:"registered_owner_info,omitempty"`
-	OperatingSystem     string          `json:"operating_system"`
-	HardwareModel       string          `json:"hardware_model"`
-	Serial              string          `json:"serial,omitempty"`
-	HardwareUuid        string          `json:"hardware_uuid,omitempty"`
-	Note                string          `json:"note,omitempty"`
-	AuthState           string          `json:"auth_state"`
-	WillBlockAt         time.Time       `json:"will_block_at,omitempty"`
-	ProductImageUrl     string          `json:"product_image_url"`
-	DeviceType          string          `json:"device_type"`
-	FormFactor          string          `json:"form_factor"`
+	Id                  string            `json:"id"`
+	Name                string            `json:"name"`
+	RegisteredAt        time.Time         `json:"registered_at,omitempty"`
+	LastAuthenticatedAt time.Time         `json:"last_authenticated_at,omitempty"`
+	RegisteredOwnerInfo RegisteredOwner   `json:"registered_owner_info,omitempty"`
+	AuthConfiguration   AuthConfiguration `json:"auth_configuration,omitempty"`
+	OperatingSystem     string            `json:"operating_system"`
+	HardwareModel       string            `json:"hardware_model"`
+	Serial              string            `json:"serial,omitempty"`
+	HardwareUuid        string            `json:"hardware_uuid,omitempty"`
+	Note                string            `json:"note,omitempty"`
+	AuthState           string            `json:"auth_state"`
+	WillBlockAt         time.Time         `json:"will_block_at,omitempty"`
+	ProductImageUrl     string            `json:"product_image_url"`
+	DeviceType          string            `json:"device_type"`
+	FormFactor          string            `json:"form_factor"`
 }
 
 type RegisteredOwner struct {
@@ -32,9 +33,9 @@ type RegisteredOwner struct {
 }
 
 type AuthConfiguration struct {
-	DeviceId           string        `json:"id"`
-	AuthenticationMode string        `json:"authentication_mode"`
-	PersonGroups       []PersonGroup `json:"person_groups"`
+	DeviceId           string        `json:"id,omitempty"`
+	AuthenticationMode string        `json:"authentication_mode,omitempty"`
+	PersonGroups       []PersonGroup `json:"person_groups,omitempty"`
 }
 
 func (c *Client) GetDevices(cursor string, limit int32, searches ...Search) (interface{}, error) {

--- a/kolide/client/devices.go
+++ b/kolide/client/devices.go
@@ -27,7 +27,8 @@ type Device struct {
 }
 
 type RegisteredOwner struct {
-	Identifier string `json:"identifier,omitempty"`
+	// Whilst the Kolide API readme entry references this as a "string", the returned value encountered during implementation is an "int"
+	Identifier int32 `json:"identifier,omitempty"`
 }
 
 type AuthConfiguration struct {

--- a/kolide/table_kolide_device.go
+++ b/kolide/table_kolide_device.go
@@ -27,7 +27,7 @@ func tableKolideDevice(_ context.Context) *plugin.Table {
 			{Name: "will_block_at", Description: "If the auth status is 'Will Block', this timestamp describes when the device will be blocked by a failing check.", Type: proto.ColumnType_TIMESTAMP},
 			{Name: "device_type", Description: "Platform type of the device, one of Mac, Windows, Linux, iOS or Android.", Type: proto.ColumnType_STRING},
 			// Other columns
-			{Name: "registered_owner_identifier", Description: "Canonical identifier for the registered owner of this device.", Type: proto.ColumnType_STRING, Transform: transform.FromField("RegisteredOwner.Identifier")},
+			{Name: "registered_owner_identifier", Description: "Canonical identifier for the registered owner of this device.", Type: proto.ColumnType_STRING, Transform: transform.FromField("RegisteredOwnerInfo.Identifier")},
 			{Name: "operating_system", Description: "Operating system installed on the device.", Type: proto.ColumnType_STRING},
 			{Name: "hardware_model", Description: "Specific hardware model of the device.", Type: proto.ColumnType_STRING},
 			{Name: "auth_state", Description: "Authorisation status of the device, one of Good, Notified, Will Block or Blocked.", Type: proto.ColumnType_STRING},

--- a/kolide/table_kolide_device.go
+++ b/kolide/table_kolide_device.go
@@ -27,14 +27,14 @@ func tableKolideDevice(_ context.Context) *plugin.Table {
 			{Name: "will_block_at", Description: "If the auth status is 'Will Block', this timestamp describes when the device will be blocked by a failing check.", Type: proto.ColumnType_TIMESTAMP},
 			{Name: "device_type", Description: "Platform type of the device, one of Mac, Windows, Linux, iOS or Android.", Type: proto.ColumnType_STRING},
 			// Other columns
-			{Name: "registered_owner_identifier", Description: "Canonical identifier for the registered owner of this device.", Type: proto.ColumnType_STRING},
+			{Name: "registered_owner_identifier", Description: "Canonical identifier for the registered owner of this device.", Type: proto.ColumnType_STRING, Transform: transform.FromField("RegisteredOwner.Identifier")},
 			{Name: "operating_system", Description: "Operating system installed on the device.", Type: proto.ColumnType_STRING},
 			{Name: "hardware_model", Description: "Specific hardware model of the device.", Type: proto.ColumnType_STRING},
 			{Name: "auth_state", Description: "Authorisation status of the device, one of Good, Notified, Will Block or Blocked.", Type: proto.ColumnType_STRING},
 			{Name: "product_image_url", Description: "URL of the device's product image.", Type: proto.ColumnType_STRING},
-			{Name: "auth_configuration_device_id", Description: "Canonical identifier for this device, empty if it is not registered", Type: proto.ColumnType_STRING},
-			{Name: "auth_configuration_authentication_mode", Description: "Who can be authenticated with this device, one of 'only_registered_owner', 'only_registered_owner_or_group_members' or 'anyone'.", Type: proto.ColumnType_STRING},
-			{Name: "auth_configuration_person_groups", Description: "Description of the groups allowed to authenticate with this device.", Type: proto.ColumnType_JSON},
+			{Name: "auth_configuration_device_id", Description: "Canonical identifier for this device, empty if it is not registered", Type: proto.ColumnType_STRING, Transform: transform.FromField("AuthConfiguration.DeviceId")},
+			{Name: "auth_configuration_authentication_mode", Description: "Who can be authenticated with this device, one of 'only_registered_owner', 'only_registered_owner_or_group_members' or 'anyone'.", Type: proto.ColumnType_STRING, Transform: transform.FromField("AuthConfiguration.AuthenticationMode")},
+			{Name: "auth_configuration_person_groups", Description: "Description of the groups allowed to authenticate with this device.", Type: proto.ColumnType_JSON, Transform: transform.FromField("AuthConfiguration.PersonGroups")},
 			{Name: "form_factor", Description: "Form factor of the device, one of Computer, Tablet or Phone.", Type: proto.ColumnType_STRING},
 			// Steampipe standard columns
 			{Name: "title", Description: "Display name for this resource.", Type: proto.ColumnType_STRING, Transform: transform.FromField("Name")},

--- a/kolide/table_kolide_device_group_device.go
+++ b/kolide/table_kolide_device_group_device.go
@@ -28,14 +28,14 @@ func tableKolideDeviceGroupDevice(_ context.Context) *plugin.Table {
 			{Name: "device_type", Description: "Platform type of the device, one of Mac, Windows, Linux, iOS or Android.", Type: proto.ColumnType_STRING},
 			// Other columns
 			{Name: "id", Description: "Canonical identifier for the device.", Type: proto.ColumnType_STRING},
-			{Name: "registered_owner_identifier", Description: "Canonical identifier for the registered owner of this device.", Type: proto.ColumnType_STRING},
+			{Name: "registered_owner_identifier", Description: "Canonical identifier for the registered owner of this device.", Type: proto.ColumnType_STRING, Transform: transform.FromField("RegisteredOwner.Identifier")},
 			{Name: "operating_system", Description: "Operating system installed on the device.", Type: proto.ColumnType_STRING},
 			{Name: "hardware_model", Description: "Specific hardware model of the device.", Type: proto.ColumnType_STRING},
 			{Name: "auth_state", Description: "Authorisation status of the device, one of Good, Notified, Will Block or Blocked.", Type: proto.ColumnType_STRING},
 			{Name: "product_image_url", Description: "URL of the device's product image.", Type: proto.ColumnType_STRING},
-			{Name: "auth_configuration_device_id", Description: "Canonical identifier for this device, empty if it is not registered", Type: proto.ColumnType_STRING},
-			{Name: "auth_configuration_authentication_mode", Description: "Who can be authenticated with this device, one of 'only_registered_owner', 'only_registered_owner_or_group_members' or 'anyone'.", Type: proto.ColumnType_STRING},
-			{Name: "auth_configuration_person_groups", Description: "Description of the groups allowed to authenticate with this device.", Type: proto.ColumnType_JSON},
+			{Name: "auth_configuration_device_id", Description: "Canonical identifier for this device, empty if it is not registered", Type: proto.ColumnType_STRING, Transform: transform.FromField("AuthConfiguration.DeviceId")},
+			{Name: "auth_configuration_authentication_mode", Description: "Who can be authenticated with this device, one of 'only_registered_owner', 'only_registered_owner_or_group_members' or 'anyone'.", Type: proto.ColumnType_STRING, Transform: transform.FromField("AuthConfiguration.AuthenticationMode")},
+			{Name: "auth_configuration_person_groups", Description: "Description of the groups allowed to authenticate with this device.", Type: proto.ColumnType_JSON, Transform: transform.FromField("AuthConfiguration.PersonGroups")},
 			{Name: "form_factor", Description: "Form factor of the device, one of Computer, Tablet or Phone.", Type: proto.ColumnType_STRING},
 			// Steampipe standard columns
 			{Name: "title", Description: "Display name for this resource.", Type: proto.ColumnType_STRING, Transform: transform.FromField("Name")},

--- a/kolide/table_kolide_device_group_device.go
+++ b/kolide/table_kolide_device_group_device.go
@@ -28,7 +28,7 @@ func tableKolideDeviceGroupDevice(_ context.Context) *plugin.Table {
 			{Name: "device_type", Description: "Platform type of the device, one of Mac, Windows, Linux, iOS or Android.", Type: proto.ColumnType_STRING},
 			// Other columns
 			{Name: "id", Description: "Canonical identifier for the device.", Type: proto.ColumnType_STRING},
-			{Name: "registered_owner_identifier", Description: "Canonical identifier for the registered owner of this device.", Type: proto.ColumnType_STRING, Transform: transform.FromField("RegisteredOwner.Identifier")},
+			{Name: "registered_owner_identifier", Description: "Canonical identifier for the registered owner of this device.", Type: proto.ColumnType_STRING, Transform: transform.FromField("RegisteredOwnerInfo.Identifier")},
 			{Name: "operating_system", Description: "Operating system installed on the device.", Type: proto.ColumnType_STRING},
 			{Name: "hardware_model", Description: "Specific hardware model of the device.", Type: proto.ColumnType_STRING},
 			{Name: "auth_state", Description: "Authorisation status of the device, one of Good, Notified, Will Block or Blocked.", Type: proto.ColumnType_STRING},

--- a/kolide/table_kolide_person_registered_device.go
+++ b/kolide/table_kolide_person_registered_device.go
@@ -28,14 +28,14 @@ func tableKolidePersonRegisteredDevice(_ context.Context) *plugin.Table {
 			{Name: "will_block_at", Description: "If the auth status is 'Will Block', this timestamp describes when the device will be blocked by a failing check.", Type: proto.ColumnType_TIMESTAMP},
 			{Name: "device_type", Description: "Platform type of the device, one of Mac, Windows, Linux, iOS or Android.", Type: proto.ColumnType_STRING},
 			// Other columns
-			{Name: "registered_owner_identifier", Description: "Canonical identifier for the registered owner of this device.", Type: proto.ColumnType_STRING},
+			{Name: "registered_owner_identifier", Description: "Canonical identifier for the registered owner of this device.", Type: proto.ColumnType_STRING, Transform: transform.FromField("RegisteredOwner.Identifier")},
 			{Name: "operating_system", Description: "Operating system installed on the device.", Type: proto.ColumnType_STRING},
 			{Name: "hardware_model", Description: "Specific hardware model of the device.", Type: proto.ColumnType_STRING},
 			{Name: "auth_state", Description: "Authorisation status of the device, one of Good, Notified, Will Block or Blocked.", Type: proto.ColumnType_STRING},
 			{Name: "product_image_url", Description: "URL of the device's product image.", Type: proto.ColumnType_STRING},
-			{Name: "auth_configuration_device_id", Description: "Canonical identifier for this device, empty if it is not registered", Type: proto.ColumnType_STRING},
-			{Name: "auth_configuration_authentication_mode", Description: "Who can be authenticated with this device, one of 'only_registered_owner', 'only_registered_owner_or_group_members' or 'anyone'.", Type: proto.ColumnType_STRING},
-			{Name: "auth_configuration_person_groups", Description: "Description of the groups allowed to authenticate with this device.", Type: proto.ColumnType_JSON},
+			{Name: "auth_configuration_device_id", Description: "Canonical identifier for this device, empty if it is not registered", Type: proto.ColumnType_STRING, Transform: transform.FromField("AuthConfiguration.DeviceId")},
+			{Name: "auth_configuration_authentication_mode", Description: "Who can be authenticated with this device, one of 'only_registered_owner', 'only_registered_owner_or_group_members' or 'anyone'.", Type: proto.ColumnType_STRING, Transform: transform.FromField("AuthConfiguration.AuthenticationMode")},
+			{Name: "auth_configuration_person_groups", Description: "Description of the groups allowed to authenticate with this device.", Type: proto.ColumnType_JSON, Transform: transform.FromField("AuthConfiguration.PersonGroups")},
 			{Name: "form_factor", Description: "Form factor of the device, one of Computer, Tablet or Phone.", Type: proto.ColumnType_STRING},
 			// Steampipe standard columns
 			{Name: "title", Description: "Display name for this resource.", Type: proto.ColumnType_STRING, Transform: transform.FromField("Name")},

--- a/kolide/table_kolide_person_registered_device.go
+++ b/kolide/table_kolide_person_registered_device.go
@@ -28,7 +28,7 @@ func tableKolidePersonRegisteredDevice(_ context.Context) *plugin.Table {
 			{Name: "will_block_at", Description: "If the auth status is 'Will Block', this timestamp describes when the device will be blocked by a failing check.", Type: proto.ColumnType_TIMESTAMP},
 			{Name: "device_type", Description: "Platform type of the device, one of Mac, Windows, Linux, iOS or Android.", Type: proto.ColumnType_STRING},
 			// Other columns
-			{Name: "registered_owner_identifier", Description: "Canonical identifier for the registered owner of this device.", Type: proto.ColumnType_STRING, Transform: transform.FromField("RegisteredOwner.Identifier")},
+			{Name: "registered_owner_identifier", Description: "Canonical identifier for the registered owner of this device.", Type: proto.ColumnType_STRING, Transform: transform.FromField("RegisteredOwnerInfo.Identifier")},
 			{Name: "operating_system", Description: "Operating system installed on the device.", Type: proto.ColumnType_STRING},
 			{Name: "hardware_model", Description: "Specific hardware model of the device.", Type: proto.ColumnType_STRING},
 			{Name: "auth_state", Description: "Authorisation status of the device, one of Good, Notified, Will Block or Blocked.", Type: proto.ColumnType_STRING},


### PR DESCRIPTION
## Description

Fixes several issues with unmarshalling Device.RegisteredOwnerInfo and Device.AuthConfiguration

## Related Tickets & Documents

closes #121 

## Steps to Verify

Run the following query using a Kolide API key with Device Trust

```sql
select name, registered_owner_identifier, auth_configuration_authentication_mode from kolide_device;
```

You should see entries for all fields