### PR TITLE
feat(tests): end-to-end test harness using BATS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,8 +10,9 @@ dist/
 *.so
 *.dylib
 
-# Test binary, built with `go test -c`
+# Test binary, built with `go test -c`, and test outputs
 *.test
+test/end-to-end/_output
 
 # Finally, local detritus
 .DS_Store

--- a/Makefile
+++ b/Makefile
@@ -13,3 +13,6 @@ install:
 
 reconfigure:
 	cp config/kolide.spc $(STEAMPIPE_INSTALL_DIR)/config/kolide.spc
+
+end-to-end:
+	bats test/end-to-end/*.bats

--- a/docs/tables/kolide_audit_log.md
+++ b/docs/tables/kolide_audit_log.md
@@ -1,4 +1,4 @@
-# Table: kolide_audit_logs
+# Table: kolide_audit_log
 
 Lists the tracked events occurring in the Kolide web console.
 
@@ -12,7 +12,7 @@ select
   description,
   actor_name
 from
-  kolide_audit_logs;
+  kolide_audit_log;
 ```
 
 ### List all events from the past day

--- a/kolide/table_kolide_admin_user.go
+++ b/kolide/table_kolide_admin_user.go
@@ -2,7 +2,6 @@ package kolide
 
 import (
 	"context"
-	"fmt"
 
 	kolide "github.com/grendel-consulting/steampipe-plugin-kolide/kolide/client"
 	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
@@ -27,7 +26,7 @@ func tableKolideAdminUser(_ context.Context) *plugin.Table {
 			{Name: "access", Description: "Access level granted to this admin user, one of full, limited or billing.", Type: proto.ColumnType_STRING},
 			{Name: "restrictions", Description: "Feature restrictions applied to this user; this list will be empty unless the user has an access level of 'limited'.", Type: proto.ColumnType_JSON},
 			// Steampipe standard columns
-			{Name: "title", Description: "Display name for this admin user.", Type: proto.ColumnType_STRING, Transform: transform.From(getFullName)},
+			{Name: "title", Description: "Display name for this admin user.", Type: proto.ColumnType_STRING, Transform: transform.FromField("FirstName")},
 		},
 		List: &plugin.ListConfig{
 			KeyColumns: []*plugin.KeyColumn{
@@ -64,14 +63,4 @@ func getAdminUser(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateDat
 	}
 
 	return getAnything(ctx, d, h, "kolide_admin_user.getAdminUser", "id", visitor)
-}
-
-//// TRANSFORM FUNCTIONS
-
-func getFullName(ctx context.Context, d *transform.TransformData) (interface{}, error) {
-	user := d.HydrateItem.(kolide.AdminUser)
-
-	full_name := fmt.Sprintf("%s %s", user.FirstName, user.LastName)
-
-	return full_name, nil
 }

--- a/kolide/utils.go
+++ b/kolide/utils.go
@@ -12,7 +12,7 @@ import (
 	quals "github.com/turbot/steampipe-plugin-sdk/v5/plugin/quals"
 )
 
-func connect(ctx context.Context, d *plugin.QueryData) (*kolide.Client, error) {
+func connect(_ context.Context, d *plugin.QueryData) (*kolide.Client, error) {
 	cacheKey := "kolide"
 	if cachedData, ok := d.ConnectionManager.Cache.Get(cacheKey); ok {
 		return cachedData.(*kolide.Client), nil
@@ -43,7 +43,7 @@ type ListPredicate func(client *kolide.Client, cursor string, limit int32, searc
 type GetPredicate func(client *kolide.Client, id string) (interface{}, error)
 type ListByIdPredicate func(client *kolide.Client, id string, cursor string, limit int32, searches ...kolide.Search) (interface{}, error)
 
-func listAnything(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData, callee string, visitor ListPredicate, target string) (interface{}, error) {
+func listAnything(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData, callee string, visitor ListPredicate, target string) (interface{}, error) {
 	// Create a slice to hold search queries
 	searches, err := query(ctx, d)
 	if err != nil {
@@ -105,7 +105,7 @@ func listAnything(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateDat
 	return nil, nil
 }
 
-func getAnything(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData, callee string, id string, visitor GetPredicate) (interface{}, error) {
+func getAnything(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData, callee string, id string, visitor GetPredicate) (interface{}, error) {
 	// Fail early if unique identifier is not present
 	uid := d.EqualsQualString(id)
 	if uid == "" {
@@ -129,7 +129,7 @@ func getAnything(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData
 
 }
 
-func listAnythingById(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData, callee string, id string, visitor ListByIdPredicate, target string) (interface{}, error) {
+func listAnythingById(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData, callee string, id string, visitor ListByIdPredicate, target string) (interface{}, error) {
 	// Fail early if unique identifier is not present
 	uid := d.EqualsQualString(id)
 	if uid == "" {
@@ -196,7 +196,7 @@ func listAnythingById(ctx context.Context, d *plugin.QueryData, h *plugin.Hydrat
 	return nil, nil
 }
 
-func query(ctx context.Context, d *plugin.QueryData) ([]kolide.Search, error) {
+func query(_ context.Context, d *plugin.QueryData) ([]kolide.Search, error) {
 	// Create a slice to hold search queries
 	searches := make([]kolide.Search, 0)
 

--- a/test/end-to-end/_query/kolide_admin_user.sql
+++ b/test/end-to-end/_query/kolide_admin_user.sql
@@ -1,0 +1,10 @@
+select
+  first_name,
+  last_name,
+  email,
+  access,
+  created_at
+from
+  kolide_admin_user
+order by
+  email desc;

--- a/test/end-to-end/_query/kolide_admin_user_by_id.sql
+++ b/test/end-to-end/_query/kolide_admin_user_by_id.sql
@@ -1,0 +1,10 @@
+select
+  first_name,
+  last_name,
+  email,
+  access,
+  created_at
+from
+  kolide_admin_user
+where
+  id = '101';

--- a/test/end-to-end/_query/kolide_audit_log.sql
+++ b/test/end-to-end/_query/kolide_audit_log.sql
@@ -1,0 +1,8 @@
+select
+  timestamp,
+  description,
+  actor_name
+from
+  kolide_audit_log
+order by
+  timestamp asc;

--- a/test/end-to-end/_query/kolide_audit_log_by_id.sql
+++ b/test/end-to-end/_query/kolide_audit_log_by_id.sql
@@ -1,0 +1,8 @@
+select
+  timestamp,
+  description,
+  actor_name
+from
+  kolide_audit_log
+where
+  id = '2415';

--- a/test/end-to-end/_query/kolide_check.sql
+++ b/test/end-to-end/_query/kolide_check.sql
@@ -1,0 +1,12 @@
+select
+  id,
+  name,
+  topics,
+  compatible_platforms,
+  targeted_groups,
+  blocking_group_names,
+  blocking_enabled
+from
+  kolide_check
+order by
+  id asc;

--- a/test/end-to-end/_query/kolide_check_by_id.sql
+++ b/test/end-to-end/_query/kolide_check_by_id.sql
@@ -1,0 +1,12 @@
+select
+  id,
+  name,
+  topics,
+  compatible_platforms,
+  targeted_groups,
+  blocking_group_names,
+  blocking_enabled
+from
+  kolide_check
+where
+  id = '1';

--- a/test/end-to-end/_query/kolide_deprovisioned_person.sql
+++ b/test/end-to-end/_query/kolide_deprovisioned_person.sql
@@ -1,0 +1,7 @@
+select
+  name,
+  email
+from
+  kolide_deprovisioned_person
+order by
+  name desc;

--- a/test/end-to-end/_query/kolide_device.sql
+++ b/test/end-to-end/_query/kolide_device.sql
@@ -1,0 +1,8 @@
+select
+  name,
+  hardware_model,
+  serial
+from
+  kolide_device
+order by
+  name desc;

--- a/test/end-to-end/_query/kolide_device_by_id.sql
+++ b/test/end-to-end/_query/kolide_device_by_id.sql
@@ -1,0 +1,8 @@
+select
+  name,
+  hardware_model,
+  serial
+from
+  kolide_device
+where
+  id = '1553';

--- a/test/end-to-end/_query/kolide_device_group.sql
+++ b/test/end-to-end/_query/kolide_device_group.sql
@@ -1,0 +1,7 @@
+select
+  id,
+  name
+from
+  kolide_device_group
+order by
+  name desc;

--- a/test/end-to-end/_query/kolide_device_group_by_id.sql
+++ b/test/end-to-end/_query/kolide_device_group_by_id.sql
@@ -1,0 +1,7 @@
+select
+  id,
+  name
+from
+  kolide_device_group
+where
+  id = '12345';

--- a/test/end-to-end/_query/kolide_device_group_device.sql
+++ b/test/end-to-end/_query/kolide_device_group_device.sql
@@ -1,0 +1,10 @@
+select
+  name,
+  hardware_model,
+  serial
+from
+  kolide_device_group_device
+where
+  device_group_id = '12345'
+order by
+  name desc;

--- a/test/end-to-end/_query/kolide_device_open_issue.sql
+++ b/test/end-to-end/_query/kolide_device_open_issue.sql
@@ -1,0 +1,12 @@
+select
+  title,
+  detected_at,
+  blocks_device_at,
+  resolved_at,
+  exempted
+from
+  kolide_device_open_issue
+where
+  device_id = '1553'
+order by
+  detected_at asc;

--- a/test/end-to-end/_query/kolide_issue.sql
+++ b/test/end-to-end/_query/kolide_issue.sql
@@ -1,0 +1,10 @@
+select
+  title,
+  detected_at,
+  blocks_device_at,
+  resolved_at,
+  exempted
+from
+  kolide_issue
+order by
+  detected_at asc;

--- a/test/end-to-end/_query/kolide_issue_by_id.sql
+++ b/test/end-to-end/_query/kolide_issue_by_id.sql
@@ -1,0 +1,10 @@
+select
+  title,
+  detected_at,
+  blocks_device_at,
+  resolved_at,
+  exempted
+from
+  kolide_issue
+where
+  id = '1959';

--- a/test/end-to-end/_query/kolide_package.sql
+++ b/test/end-to-end/_query/kolide_package.sql
@@ -1,0 +1,9 @@
+select
+  id,
+  built_at,
+  version,
+  url
+from
+  kolide_package
+order by
+  id asc;

--- a/test/end-to-end/_query/kolide_package_by_id.sql
+++ b/test/end-to-end/_query/kolide_package_by_id.sql
@@ -1,0 +1,9 @@
+select
+  id,
+  built_at,
+  version,
+  url
+from
+  kolide_package
+where
+  id = 'darwin-launchd-pkg';

--- a/test/end-to-end/_query/kolide_person.sql
+++ b/test/end-to-end/_query/kolide_person.sql
@@ -1,0 +1,9 @@
+select
+  id,
+  name,
+  email,
+  has_registered_device
+from
+  kolide_person
+order by
+  name desc;

--- a/test/end-to-end/_query/kolide_person_by_id.sql
+++ b/test/end-to-end/_query/kolide_person_by_id.sql
@@ -1,0 +1,9 @@
+select
+  id,
+  name,
+  email,
+  has_registered_device
+from
+  kolide_person
+where
+  id = '12345';

--- a/test/end-to-end/_query/kolide_person_group.sql
+++ b/test/end-to-end/_query/kolide_person_group.sql
@@ -1,0 +1,7 @@
+select
+  id,
+  name
+from
+  kolide_person_group
+order by
+  name desc;

--- a/test/end-to-end/_query/kolide_person_group_by_id.sql
+++ b/test/end-to-end/_query/kolide_person_group_by_id.sql
@@ -1,0 +1,7 @@
+select
+  id,
+  name
+from
+  kolide_person_group
+where
+  id = '12345';

--- a/test/end-to-end/_query/kolide_person_open_issue.sql
+++ b/test/end-to-end/_query/kolide_person_open_issue.sql
@@ -1,0 +1,12 @@
+select
+  title,
+  detected_at,
+  blocks_device_at,
+  resolved_at,
+  exempted
+from
+  kolide_person_open_issue
+where
+  person_id = '12345'
+order by
+  detected_at asc;

--- a/test/end-to-end/_query/kolide_person_registered_device.sql
+++ b/test/end-to-end/_query/kolide_person_registered_device.sql
@@ -1,0 +1,10 @@
+select
+  name,
+  hardware_model,
+  serial
+from
+  kolide_person_registered_device
+where
+  person_id = '12345'
+order by
+  name desc;

--- a/test/end-to-end/_results/kolide_admin_user.bash
+++ b/test/end-to-end/_results/kolide_admin_user.bash
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+define_test_results(){
+    # export EXPECTED_COUNT=""
+    export FIRST_NAME="James"
+    export LAST_NAME="Ramirez"
+    # export EMAIL=""
+    export ACCESS="full"
+    # export CREATED_AT=""
+}

--- a/test/end-to-end/_results/kolide_audit_log.bash
+++ b/test/end-to-end/_results/kolide_audit_log.bash
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+define_test_results(){
+    # export EXPECTED_COUNT=""
+    export TIMESTAMP="2020-01"
+    export DESCRIPTION="Live Query Campaign"
+    # export ACTOR_NAME=""
+}

--- a/test/end-to-end/_results/kolide_check.bash
+++ b/test/end-to-end/_results/kolide_check.bash
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+define_test_results(){
+    # export EXPECTED_COUNT=""
+    # export ID=""
+    export NAME="macOS Sharing - Require Bluetooth Sharing to Be Disabled"
+    export TOPICS="sharing-preferences"
+    export COMPATIBLE_PLATFORMS="darwin"
+    export TARGETED_GROUPS="macOS"
+    export BLOCKING_GROUP_NAMES="macOS"
+    export BLOCKING_ENABLED="false"
+}

--- a/test/end-to-end/_results/kolide_deprovisioned_person.bash
+++ b/test/end-to-end/_results/kolide_deprovisioned_person.bash
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+define_test_results(){
+    # Unexpected behaviour in Kolide API under K2; this endpoint returns an existing active users
+    export EXPECTED_COUNT="2"
+    # export NAME=""
+    # export EMAIL=""
+}

--- a/test/end-to-end/_results/kolide_device.bash
+++ b/test/end-to-end/_results/kolide_device.bash
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+define_test_results(){
+    # export EXPECTED_COUNT=""
+    export NAME="ikebana"
+    export HARDWARE_MODEL="MacBook Pro"
+    export SERIAL="C02V40F2HV2Q"
+}

--- a/test/end-to-end/_results/kolide_device_open_issue.bash
+++ b/test/end-to-end/_results/kolide_device_open_issue.bash
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+define_test_results(){
+    # export EXPECTED_COUNT=""
+    export TITLE="Device Battery Requires Servicing"
+    # export DETECTED_AT=""
+    # export BLOCKS_DEVICE_AT=""
+    # export RESOLVED_AT=""
+    # export EXEMPTED=""
+}

--- a/test/end-to-end/_results/kolide_issue.bash
+++ b/test/end-to-end/_results/kolide_issue.bash
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+define_test_results(){
+    # export EXPECTED_COUNT=""
+    export TITLE="File Extensions not visible in Finder"
+    # export DETECTED_AT=""
+    # export BLOCKS_DEVICE_AT=""
+    # export RESOLVED_AT=""
+    # export EXEMPTED=""
+
+}

--- a/test/end-to-end/_results/kolide_package.bash
+++ b/test/end-to-end/_results/kolide_package.bash
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+define_test_results(){
+    export EXPECTED_COUNT="4"
+    export ID="darwin-launchd-pkg"
+    # export BUILT_AT=""
+    # export VERSION=""
+    export URL="https://api.kolide.com/package_downloads/darwin-launchd-pkg"
+}

--- a/test/end-to-end/_results/kolide_person.bash
+++ b/test/end-to-end/_results/kolide_person.bash
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+define_test_results(){
+    # Unexpected behaviour in Kolide API under K2; this endpoint returns an empty list
+    export EXPECTED_COUNT="0"
+    # export ID=""
+    # export NAME=""
+    # export EMAIL=""
+    # export HAS_REGISTERED_DEVICE=""
+}

--- a/test/end-to-end/_results/kolide_person_open_issues.bash
+++ b/test/end-to-end/_results/kolide_person_open_issues.bash
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+define_test_results(){
+    # Unexpected behaviour in Kolide API under K2; this endpoint returns an empty list
+    export EXPECTED_COUNT="0"
+    # export TITLE=""
+    # export DETECTED_AT=""
+    # export BLOCKS_DEVICE_AT=""
+    # export RESOLVED_AT=""
+    # export EXEMPTED=""
+}

--- a/test/end-to-end/_results/kolide_person_registered_device.bash
+++ b/test/end-to-end/_results/kolide_person_registered_device.bash
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+define_test_results(){
+    # Unexpected behaviour in Kolide API under K2; this endpoint returns an empty list
+    export EXPECTED_COUNT="0"
+    # export NAME=""
+    # export HARDWARE_MODEL=""
+    # export SERIAL=""
+
+}

--- a/test/end-to-end/_support/extensions.bash
+++ b/test/end-to-end/_support/extensions.bash
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+load_helpers(){
+    # We want to check return codes for some tests, hence run flags need to be enabled
+    bats_require_minimum_version 1.5.0
+
+    # For now, presume running locally on MacBook with BATS installed via Homebrew
+    TEST_HELPER_INSTALL_ROOT="$(brew --prefix)"
+
+    load "${TEST_HELPER_INSTALL_ROOT}/lib/bats-assert/load.bash"
+    load "${TEST_HELPER_INSTALL_ROOT}/lib/bats-file/load.bash"
+}

--- a/test/end-to-end/_support/extensions.bash
+++ b/test/end-to-end/_support/extensions.bash
@@ -5,7 +5,12 @@ load_helpers(){
     bats_require_minimum_version 1.5.0
 
     # For now, presume running locally on MacBook with BATS installed via Homebrew
-    TEST_HELPER_INSTALL_ROOT="$(brew --prefix)"
+    if command -v brew &>/dev/null; then
+        TEST_HELPER_INSTALL_ROOT="$(brew --prefix)"
+    else
+        echo "Homebrew not found. Please ensure the necessary BATS support files are installed."
+        exit 1
+    fi
 
     load "${TEST_HELPER_INSTALL_ROOT}/lib/bats-assert/load.bash"
     load "${TEST_HELPER_INSTALL_ROOT}/lib/bats-file/load.bash"

--- a/test/end-to-end/_support/globals.bash
+++ b/test/end-to-end/_support/globals.bash
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+
+define_file_globals(){
+    export TABLE_UNDER_TEST=$(basename $BATS_TEST_FILENAME ".bats")
+    export QUERY_UNDER_TEST="${BATS_TEST_DIRNAME}/_query/${TABLE_UNDER_TEST}.sql"
+    export QUERY_RESULTS="${BATS_TEST_DIRNAME}/_output/${TABLE_UNDER_TEST}.json"
+}
+
+# Given we expect most tables to be relatively stable sets, we will
+# make the first alphabetical entry our test results; where not, we will
+# rely less on static test values and look for non-failing execution
+#
+# Unless otherwise required, tests will use the 'basic info' queries
+# with an `order by` clause to ensure repeatability
+define_test_results(){
+    export KOLIDE_PLAN="K2"
+
+    export MY_DEFAULT_EMAIL_DOMAIN="@grendel-consulting.com"
+
+    export MY_ADMIN_USER_COUNT="1"
+    export MY_TOP_ADMIN_USER_FIRST_NAME="James"
+    export MY_TOP_ADMIN_USER_LAST_NAME="Ramirez"
+    export MY_TOP_ADMIN_USER_ACCESS="full"
+
+    # Given volatile table, no count based test
+    export MY_TOP_AUDIT_LOG_TIMESTAMP="2020-01"
+    export MY_TOP_AUDIT_LOG_DESCRIPTION="Live Query Campaign"
+    export MY_TOP_AUDIT_LOG_ACTOR_NAME="James Ramirez"
+
+    # Potentially volatile as Kolide, or tenant, may define and release new checks
+    export MY_CHECK_COUNT="61"
+    export MY_TOP_CHECK_NAME="macOS Sharing - Require Bluetooth Sharing to Be Disabled"
+    export MY_TOP_CHECK_TOPICS="sharing-preferences"
+    export MY_TOP_CHECK_COMPATIBLE_PLATFORMS="darwin"
+    export MY_TOP_CHECK_TARGETED_GROUPS="macOS"
+    export MY_TOP_CHECK_BLOCKING_GROUP_NAMES="macOS"
+    export MY_TOP_CHECK_BLOCKING_ENABLED="false"
+
+    export MY_DEPROVISIONED_PERSON_COUNT="2"
+    export MY_TOP_DEPROVISIONED_USER_NAME="Cloud Manager"
+
+    # Given 403, no expected results for device groups, or device group devices
+
+    # Given volatile table, no count based test
+    export MY_TOP_DEVICE_OPEN_ISSUE_TITLE="Device Battery Requires Servicing"
+
+    export MY_DEVICE_COUNT="2"
+    export MY_TOP_DEVICE_NAME="ikebana"
+    export MY_TOP_DEVICE_HARDWARE_MODEL="MacBook Pro"
+    export MY_TOP_DEVICE_SERIAL="C02V40F2HV2Q"
+
+    # Given volatile table, no count based test
+    export MY_TOP_ISSUE_TITLE="File Extensions not visible in Finder"
+
+    export MY_PACKAGE_COUNT="4"
+    export MY_TOP_PACKAGE_ID="darwin-launchd-pkg"
+    export MY_TOP_PACKAGE_URL="https://api.kolide.com/package_downloads/darwin-launchd-pkg"
+
+    # Given 403, no expected results for person groups
+
+    # Given zero entries, minimal expected results for person
+    export MY_PERSON_COUNT="0"
+    export MY_TOP_PERSON_NAME="Xerxes"
+    export MY_TOP_PERSON_REGISTERED_DEVICE="false"
+
+    # Given zero entries, minimal expected results for person open issues
+    export MY_PERSON_OPEN_ISSUE_COUNT="0"
+    export MY_TOP_PERSON_OPEN_ISSUE_TITLE="Device Battery Requires Servicing"
+
+    # Given zero entries, minimal expected results for person registered devices
+    export MY_PERSON_REGISTERED_DEVICE_COUNT="0"
+    export MY_TOP_PERSON_REGISTERED_DEVICE_NAME="ikebana"
+    export MY_TOP_PERSON_REGISTERED_DEVICE_HARDWARE_MODEL="MacBook Pro"
+    export MY_TOP_PERSON_REGISTERED_DEVICE_SERIAL="C02V40F2HV2Q"
+}

--- a/test/end-to-end/_support/globals.bash
+++ b/test/end-to-end/_support/globals.bash
@@ -1,75 +1,15 @@
 #!/usr/bin/env bash
 
+
 define_file_globals(){
-    export TABLE_UNDER_TEST=$(basename $BATS_TEST_FILENAME ".bats")
+    export TABLE_UNDER_TEST=$(basename "$BATS_TEST_FILENAME" ".bats")
+    export EXPECTED_RESULTS="${BATS_TEST_DIRNAME}/_results/${TABLE_UNDER_TEST}.bash"
     export QUERY_UNDER_TEST="${BATS_TEST_DIRNAME}/_query/${TABLE_UNDER_TEST}.sql"
     export QUERY_RESULTS="${BATS_TEST_DIRNAME}/_output/${TABLE_UNDER_TEST}.json"
+
+    export MY_KOLIDE_PLAN="K2"
 }
 
-# Given we expect most tables to be relatively stable sets, we will
-# make the first alphabetical entry our test results; where not, we will
-# rely less on static test values and look for non-failing execution
-#
-# Unless otherwise required, tests will use the 'basic info' queries
-# with an `order by` clause to ensure repeatability
-define_test_results(){
-    export KOLIDE_PLAN="K2"
-
+define_common_test_results(){
     export MY_DEFAULT_EMAIL_DOMAIN="@grendel-consulting.com"
-
-    export MY_ADMIN_USER_COUNT="1"
-    export MY_TOP_ADMIN_USER_FIRST_NAME="James"
-    export MY_TOP_ADMIN_USER_LAST_NAME="Ramirez"
-    export MY_TOP_ADMIN_USER_ACCESS="full"
-
-    # Given volatile table, no count based test
-    export MY_TOP_AUDIT_LOG_TIMESTAMP="2020-01"
-    export MY_TOP_AUDIT_LOG_DESCRIPTION="Live Query Campaign"
-    export MY_TOP_AUDIT_LOG_ACTOR_NAME="James Ramirez"
-
-    # Potentially volatile as Kolide, or tenant, may define and release new checks
-    export MY_CHECK_COUNT="61"
-    export MY_TOP_CHECK_NAME="macOS Sharing - Require Bluetooth Sharing to Be Disabled"
-    export MY_TOP_CHECK_TOPICS="sharing-preferences"
-    export MY_TOP_CHECK_COMPATIBLE_PLATFORMS="darwin"
-    export MY_TOP_CHECK_TARGETED_GROUPS="macOS"
-    export MY_TOP_CHECK_BLOCKING_GROUP_NAMES="macOS"
-    export MY_TOP_CHECK_BLOCKING_ENABLED="false"
-
-    export MY_DEPROVISIONED_PERSON_COUNT="2"
-    export MY_TOP_DEPROVISIONED_USER_NAME="Cloud Manager"
-
-    # Given 403, no expected results for device groups, or device group devices
-
-    # Given volatile table, no count based test
-    export MY_TOP_DEVICE_OPEN_ISSUE_TITLE="Device Battery Requires Servicing"
-
-    export MY_DEVICE_COUNT="2"
-    export MY_TOP_DEVICE_NAME="ikebana"
-    export MY_TOP_DEVICE_HARDWARE_MODEL="MacBook Pro"
-    export MY_TOP_DEVICE_SERIAL="C02V40F2HV2Q"
-
-    # Given volatile table, no count based test
-    export MY_TOP_ISSUE_TITLE="File Extensions not visible in Finder"
-
-    export MY_PACKAGE_COUNT="4"
-    export MY_TOP_PACKAGE_ID="darwin-launchd-pkg"
-    export MY_TOP_PACKAGE_URL="https://api.kolide.com/package_downloads/darwin-launchd-pkg"
-
-    # Given 403, no expected results for person groups
-
-    # Given zero entries, minimal expected results for person
-    export MY_PERSON_COUNT="0"
-    export MY_TOP_PERSON_NAME="Xerxes"
-    export MY_TOP_PERSON_REGISTERED_DEVICE="false"
-
-    # Given zero entries, minimal expected results for person open issues
-    export MY_PERSON_OPEN_ISSUE_COUNT="0"
-    export MY_TOP_PERSON_OPEN_ISSUE_TITLE="Device Battery Requires Servicing"
-
-    # Given zero entries, minimal expected results for person registered devices
-    export MY_PERSON_REGISTERED_DEVICE_COUNT="0"
-    export MY_TOP_PERSON_REGISTERED_DEVICE_NAME="ikebana"
-    export MY_TOP_PERSON_REGISTERED_DEVICE_HARDWARE_MODEL="MacBook Pro"
-    export MY_TOP_PERSON_REGISTERED_DEVICE_SERIAL="C02V40F2HV2Q"
 }

--- a/test/end-to-end/kolide_admin_user.bats
+++ b/test/end-to-end/kolide_admin_user.bats
@@ -1,0 +1,58 @@
+# bats file_tags=table:kolide_admin_user, output:admin_user
+
+setup_file() {
+    load "${BATS_TEST_DIRNAME}/_support/globals.bash"
+    define_file_globals
+    define_test_results
+}
+
+setup() {
+    load "${BATS_TEST_DIRNAME}/_support/extensions.bash"
+    load_helpers
+}
+
+#bats test_tags=scope:smoke
+@test "can_execute_query_via_steampipe" {
+    steampipe query $QUERY_UNDER_TEST --output json > $QUERY_RESULTS
+    assert_exists $QUERY_RESULTS
+}
+
+#bats test_tags=scope:smoke
+@test "has_expected_number_of_results" {
+    if ![[ -e $QUERY_RESULTS ]]; then skip ; fi
+
+    run bash -c "cat $QUERY_RESULTS | jq -r '. | length'"
+    assert_output $MY_ADMIN_USER_COUNT
+}
+
+@test "has_expected_first_name" {
+    if ![[ -e $QUERY_RESULTS ]]; then skip ; fi
+
+    run bash -c "cat $QUERY_RESULTS | jq -r '.[0].first_name'"
+    assert_output $MY_TOP_ADMIN_USER_FIRST_NAME
+}
+
+@test "has_expected_last_name" {
+    if ![[ -e $QUERY_RESULTS ]]; then skip ; fi
+
+    run bash -c "cat $QUERY_RESULTS | jq -r '.[0].last_name'"
+    assert_output $MY_TOP_ADMIN_USER_LAST_NAME
+}
+
+@test "has_expected_email_domain" {
+    if ![[ -e $QUERY_RESULTS ]]; then skip ; fi
+
+    run bash -c "cat $QUERY_RESULTS | jq -r '.[0].email'"
+    assert_output --partial $MY_DEFAULT_EMAIL_DOMAIN
+}
+
+@test "has_expected_access" {
+    if ![[ -e $QUERY_RESULTS ]]; then skip; fi
+
+    run bash -c "cat $QUERY_RESULTS | jq -r '.[0].access'"
+    assert_output $MY_TOP_ADMIN_USER_ACCESS
+}
+
+teardown_file(){
+    rm -f $QUERY_RESULTS
+}

--- a/test/end-to-end/kolide_admin_user.bats
+++ b/test/end-to-end/kolide_admin_user.bats
@@ -3,7 +3,12 @@
 setup_file() {
     load "${BATS_TEST_DIRNAME}/_support/globals.bash"
     define_file_globals
-    define_test_results
+
+    define_common_test_results
+
+    if [[ -f $EXPECTED_RESULTS ]]; then
+        load $EXPECTED_RESULTS
+    fi
 }
 
 setup() {
@@ -17,42 +22,56 @@ setup() {
     assert_exists $QUERY_RESULTS
 }
 
-#bats test_tags=scope:smoke
 @test "has_expected_number_of_results" {
-    if ![[ -e $QUERY_RESULTS ]]; then skip ; fi
+    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
 
     run bash -c "cat $QUERY_RESULTS | jq -r '. | length'"
-    assert_output $MY_ADMIN_USER_COUNT
+
+    if [[ -z "$EXPECTED_COUNT" ]]; then assert_output $EXPECTED_COUNT ; else assert [ "$output" -ge "1" ] ; fi
 }
 
 @test "has_expected_first_name" {
-    if ![[ -e $QUERY_RESULTS ]]; then skip ; fi
+    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
 
     run bash -c "cat $QUERY_RESULTS | jq -r '.[0].first_name'"
-    assert_output $MY_TOP_ADMIN_USER_FIRST_NAME
+    if [[ -z "$FIRST_NAME" ]]; then assert_output $FIRST_NAME ; else assert_success ; fi
 }
 
 @test "has_expected_last_name" {
-    if ![[ -e $QUERY_RESULTS ]]; then skip ; fi
+    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
 
     run bash -c "cat $QUERY_RESULTS | jq -r '.[0].last_name'"
-    assert_output $MY_TOP_ADMIN_USER_LAST_NAME
+    if [[ -z "$LAST_NAME" ]]; then assert_output $LAST_NAME ; else assert_success ; fi
 }
 
-@test "has_expected_email_domain" {
-    if ![[ -e $QUERY_RESULTS ]]; then skip ; fi
+#bats test_tags=exactness:fallback
+@test "has_expected_email" {
+    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
 
     run bash -c "cat $QUERY_RESULTS | jq -r '.[0].email'"
-    assert_output --partial $MY_DEFAULT_EMAIL_DOMAIN
+    if [[ -z "$EMAIL" ]]; then assert_output $EMAIL ; else assert_output --partial $MY_DEFAULT_EMAIL_DOMAIN ; fi
 }
 
+#bats test_tags=exactness:default
 @test "has_expected_access" {
-    if ![[ -e $QUERY_RESULTS ]]; then skip; fi
+    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
 
     run bash -c "cat $QUERY_RESULTS | jq -r '.[0].access'"
-    assert_output $MY_TOP_ADMIN_USER_ACCESS
+    if [[ -z "$ACCESS" ]]; then assert_output $ACCESS ; else assert_output "full" ; fi
 }
 
+#bats test_tags=exactness:fuzzy
+@test "has_expected_created_at" {
+    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
+
+    run bash -c "cat $QUERY_RESULTS | jq -r '.[0].created_at'"
+    if [[ -z "$CREATED_AT" ]]; then assert_output --partial $CREATED_AT ; else assert_success ; fi
+}
+
+
+
 teardown_file(){
-    rm -f $QUERY_RESULTS
+    if [[ -f $QUERY_RESULTS ]]; then
+        rm -f $QUERY_RESULTS
+    fi
 }

--- a/test/end-to-end/kolide_admin_user_by_id.bats
+++ b/test/end-to-end/kolide_admin_user_by_id.bats
@@ -1,0 +1,32 @@
+# bats file_tags=table:kolide_admin_user, output:admin_user
+
+setup_file() {
+    load "${BATS_TEST_DIRNAME}/_support/globals.bash"
+    define_file_globals
+    define_test_results
+}
+
+setup() {
+    load "${BATS_TEST_DIRNAME}/_support/extensions.bash"
+    load_helpers
+}
+
+#bats test_tags=scope:smoke
+@test "can_execute_query_via_steampipe" {
+    steampipe query $QUERY_UNDER_TEST --output json > $QUERY_RESULTS
+    assert_exists $QUERY_RESULTS
+}
+
+#bats test_tags=scope:smoke
+@test "has_exactly_one_result" {
+    if ![[ -e $QUERY_RESULTS ]]; then skip ; fi
+
+    run bash -c "cat $QUERY_RESULTS | jq -r '. | length'"
+    assert_output "1"
+}
+
+# Remaining functionality covered in kolide_admin_user.bats
+
+teardown_file(){
+    rm -f $QUERY_RESULTS
+}

--- a/test/end-to-end/kolide_admin_user_by_id.bats
+++ b/test/end-to-end/kolide_admin_user_by_id.bats
@@ -3,7 +3,6 @@
 setup_file() {
     load "${BATS_TEST_DIRNAME}/_support/globals.bash"
     define_file_globals
-    define_test_results
 }
 
 setup() {
@@ -17,16 +16,17 @@ setup() {
     assert_exists $QUERY_RESULTS
 }
 
-#bats test_tags=scope:smoke
-@test "has_exactly_one_result" {
-    if ![[ -e $QUERY_RESULTS ]]; then skip ; fi
+@test "has_no_more_than_one_result" {
+    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
 
     run bash -c "cat $QUERY_RESULTS | jq -r '. | length'"
-    assert_output "1"
+    assert [ "$output" -le "1" ]
 }
 
 # Remaining functionality covered in kolide_admin_user.bats
 
 teardown_file(){
-    rm -f $QUERY_RESULTS
+    if [[ -f $QUERY_RESULTS ]]; then
+        rm -f $QUERY_RESULTS
+    fi
 }

--- a/test/end-to-end/kolide_audit_log.bats
+++ b/test/end-to-end/kolide_audit_log.bats
@@ -3,7 +3,12 @@
 setup_file() {
     load "${BATS_TEST_DIRNAME}/_support/globals.bash"
     define_file_globals
-    define_test_results
+
+    define_common_test_results
+
+    if [[ -f $EXPECTED_RESULTS ]]; then
+        load $EXPECTED_RESULTS
+    fi
 }
 
 setup() {
@@ -17,32 +22,40 @@ setup() {
     assert_exists $QUERY_RESULTS
 }
 
-#bats test_tags=scope:smoke
 @test "has_expected_number_of_results" {
-    skip "too volatile"
+    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
+
+    run bash -c "cat $QUERY_RESULTS | jq -r '. | length'"
+
+    if [[ -z "$EXPECTED_COUNT" ]]; then assert_output $EXPECTED_COUNT ; else assert [ "$output" -ge "1" ] ; fi
 }
 
+#bats test_tags=exactness:fuzzy
 @test "has_expected_timestamp" {
-    if ![[ -e $QUERY_RESULTS ]]; then skip ; fi
+    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
 
     run bash -c "cat $QUERY_RESULTS | jq -r '.[0].timestamp'"
-    assert_output --partial $MY_TOP_AUDIT_LOG_TIMESTAMP
+    if [[ -z "$TIMESTAMP" ]]; then assert_output --partial $TIMESTAMP ; else assert_success ; fi
 }
 
+#bats test_tags=exactness:fuzzy
 @test "has_expected_description" {
-    if ![[ -e $QUERY_RESULTS ]]; then skip ; fi
+    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
 
     run bash -c "cat $QUERY_RESULTS | jq -r '.[0].description'"
-    assert_output --partial $MY_TOP_AUDIT_LOG_DESCRIPTION
+    if [[ -z "$DESCRIPTION" ]]; then assert_output --partial $DESCRIPTION ; else assert_success ; fi
 }
 
+#bats test_tags=exactness:fuzzy
 @test "has_expected_actor_name" {
-    if ![[ -e $QUERY_RESULTS ]]; then skip ; fi
+    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
 
     run bash -c "cat $QUERY_RESULTS | jq -r '.[0].actor_name'"
-    assert_output --partial $MY_TOP_AUDIT_LOG_ACTOR_NAME
+    if [[ -z "$ACTOR_NAME" ]]; then assert_output --partial $ACTOR_NAME ; else assert_success ; fi
 }
 
 teardown_file(){
-    rm -f $QUERY_RESULTS
+    if [[ -f $QUERY_RESULTS ]]; then
+        rm -f $QUERY_RESULTS
+    fi
 }

--- a/test/end-to-end/kolide_audit_log.bats
+++ b/test/end-to-end/kolide_audit_log.bats
@@ -1,0 +1,48 @@
+# bats file_tags=table:kolide_audit_log, output:audit_log
+
+setup_file() {
+    load "${BATS_TEST_DIRNAME}/_support/globals.bash"
+    define_file_globals
+    define_test_results
+}
+
+setup() {
+    load "${BATS_TEST_DIRNAME}/_support/extensions.bash"
+    load_helpers
+}
+
+#bats test_tags=scope:smoke
+@test "can_execute_query_via_steampipe" {
+    steampipe query $QUERY_UNDER_TEST --output json > $QUERY_RESULTS
+    assert_exists $QUERY_RESULTS
+}
+
+#bats test_tags=scope:smoke
+@test "has_expected_number_of_results" {
+    skip "too volatile"
+}
+
+@test "has_expected_timestamp" {
+    if ![[ -e $QUERY_RESULTS ]]; then skip ; fi
+
+    run bash -c "cat $QUERY_RESULTS | jq -r '.[0].timestamp'"
+    assert_output --partial $MY_TOP_AUDIT_LOG_TIMESTAMP
+}
+
+@test "has_expected_description" {
+    if ![[ -e $QUERY_RESULTS ]]; then skip ; fi
+
+    run bash -c "cat $QUERY_RESULTS | jq -r '.[0].description'"
+    assert_output --partial $MY_TOP_AUDIT_LOG_DESCRIPTION
+}
+
+@test "has_expected_actor_name" {
+    if ![[ -e $QUERY_RESULTS ]]; then skip ; fi
+
+    run bash -c "cat $QUERY_RESULTS | jq -r '.[0].actor_name'"
+    assert_output --partial $MY_TOP_AUDIT_LOG_ACTOR_NAME
+}
+
+teardown_file(){
+    rm -f $QUERY_RESULTS
+}

--- a/test/end-to-end/kolide_audit_log_by_id.bats
+++ b/test/end-to-end/kolide_audit_log_by_id.bats
@@ -16,16 +16,17 @@ setup() {
     assert_exists $QUERY_RESULTS
 }
 
-#bats test_tags=scope:smoke
-@test "has_exactly_one_result" {
-    if ![[ -e $QUERY_RESULTS ]]; then skip ; fi
+@test "has_no_more_than_one_result" {
+    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
 
     run bash -c "cat $QUERY_RESULTS | jq -r '. | length'"
-    assert_output "1"
+    assert [ "$output" -le "1" ]
 }
 
 # Remaining functionality covered in kolide_audit_log.bats
 
 teardown_file(){
-    rm -f $QUERY_RESULTS
+    if [[ -f $QUERY_RESULTS ]]; then
+        rm -f $QUERY_RESULTS
+    fi
 }

--- a/test/end-to-end/kolide_audit_log_by_id.bats
+++ b/test/end-to-end/kolide_audit_log_by_id.bats
@@ -1,0 +1,31 @@
+# bats file_tags=table:kolide_audit_log, output:audit_log
+
+setup_file() {
+    load "${BATS_TEST_DIRNAME}/_support/globals.bash"
+    define_file_globals
+}
+
+setup() {
+    load "${BATS_TEST_DIRNAME}/_support/extensions.bash"
+    load_helpers
+}
+
+#bats test_tags=scope:smoke
+@test "can_execute_query_via_steampipe" {
+    steampipe query $QUERY_UNDER_TEST --output json > $QUERY_RESULTS
+    assert_exists $QUERY_RESULTS
+}
+
+#bats test_tags=scope:smoke
+@test "has_exactly_one_result" {
+    if ![[ -e $QUERY_RESULTS ]]; then skip ; fi
+
+    run bash -c "cat $QUERY_RESULTS | jq -r '. | length'"
+    assert_output "1"
+}
+
+# Remaining functionality covered in kolide_audit_log.bats
+
+teardown_file(){
+    rm -f $QUERY_RESULTS
+}

--- a/test/end-to-end/kolide_check.bats
+++ b/test/end-to-end/kolide_check.bats
@@ -3,7 +3,12 @@
 setup_file() {
     load "${BATS_TEST_DIRNAME}/_support/globals.bash"
     define_file_globals
-    define_test_results
+
+    define_common_test_results
+
+    if [[ -f $EXPECTED_RESULTS ]]; then
+        load $EXPECTED_RESULTS
+    fi
 }
 
 setup() {
@@ -17,56 +22,70 @@ setup() {
     assert_exists $QUERY_RESULTS
 }
 
-#bats test_tags=scope:smoke
 @test "has_expected_number_of_results" {
-    if ![[ -e $QUERY_RESULTS ]]; then skip ; fi
+    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
 
     run bash -c "cat $QUERY_RESULTS | jq -r '. | length'"
-    assert_output $MY_CHECK_COUNT
+
+    if [[ -z "$EXPECTED_COUNT" ]]; then assert_output $EXPECTED_COUNT ; else assert [ "$output" -ge "1" ] ; fi
+}
+
+@test "has_expected_id" {
+    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
+
+    run bash -c "cat $QUERY_RESULTS | jq -r '.[0].id'"
+    if [[ -z "$ID" ]]; then assert_output $ID ; else assert_success ; fi
 }
 
 @test "has_expected_name" {
-    if ![[ -e $QUERY_RESULTS ]]; then skip ; fi
+    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
 
     run bash -c "cat $QUERY_RESULTS | jq -r '.[0].name'"
-    assert_output --partial $MY_TOP_CHECK_NAME
+    if [[ -z "$NAME" ]]; then assert_output $NAME ; else assert_success ; fi
 }
 
+#bats test_tags=exactness:fuzzy
 @test "has_expected_topics" {
-    if ![[ -e $QUERY_RESULTS ]]; then skip ; fi
+    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
 
     run bash -c "cat $QUERY_RESULTS | jq -r '.[0].topics'"
-    assert_output --partial $MY_TOP_CHECK_TOPICS
+    if [[ -z "$TOPICS" ]]; then assert_output --partial $TOPICS ; else assert_success ; fi
 }
 
+#bats test_tags=exactness:fuzzy
 @test "has_expected_compatible_platforms" {
-    if ![[ -e $QUERY_RESULTS ]]; then skip ; fi
+    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
 
     run bash -c "cat $QUERY_RESULTS | jq -r '.[0].compatible_platforms'"
-    assert_output --partial $MY_TOP_CHECK_COMPATIBLE_PLATFORMS
+    if [[ -z "$COMPATIBLE_PLATFORMS" ]]; then assert_output --partial $COMPATIBLE_PLATFORMS ; else assert_success ; fi
 }
 
+#bats test_tags=exactness:fuzzy
 @test "has_expected_targeted_groups" {
-    if ![[ -e $QUERY_RESULTS ]]; then skip ; fi
+    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
 
     run bash -c "cat $QUERY_RESULTS | jq -r '.[0].targeted_groups'"
-    assert_output --partial $MY_TOP_CHECK_TARGETED_GROUPS
+    if [[ -z "$TARGETED_GROUPS" ]]; then assert_output --partial $TARGETED_GROUPS ; else assert_success ; fi
 }
 
+#bats test_tags=exactness:fuzzy
 @test "has_expected_blocking_group_names" {
-    if ![[ -e $QUERY_RESULTS ]]; then skip ; fi
+    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
 
     run bash -c "cat $QUERY_RESULTS | jq -r '.[0].blocking_group_names'"
-    assert_output --partial $MY_TOP_CHECK_BLOCKING_GROUP_NAMES
+    if [[ -z "$BLOCKING_GROUP_NAMES" ]]; then assert_output --partial $BLOCKING_GROUP_NAMES ; else assert_success ; fi
 }
 
+#bats test_tags=exactness:default
 @test "has_expected_blocking_enabled" {
-    if ![[ -e $QUERY_RESULTS ]]; then skip ; fi
+    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
 
     run bash -c "cat $QUERY_RESULTS | jq -r '.[0].blocking_enabled'"
-    assert_output --partial $MY_TOP_CHECK_BLOCKING_ENABLED
+    if [[ -z "$BLOCKING_ENABLED" ]]; then assert_output $BLOCKING_ENABLED ; else assert_output "false" ; fi
 }
 
 teardown_file(){
-    rm -f $QUERY_RESULTS
+    if [[ -f $QUERY_RESULTS ]]; then
+        rm -f $QUERY_RESULTS
+    fi
 }

--- a/test/end-to-end/kolide_check.bats
+++ b/test/end-to-end/kolide_check.bats
@@ -1,0 +1,72 @@
+# bats file_tags=table:kolide_check, output:check
+
+setup_file() {
+    load "${BATS_TEST_DIRNAME}/_support/globals.bash"
+    define_file_globals
+    define_test_results
+}
+
+setup() {
+    load "${BATS_TEST_DIRNAME}/_support/extensions.bash"
+    load_helpers
+}
+
+#bats test_tags=scope:smoke
+@test "can_execute_query_via_steampipe" {
+    steampipe query $QUERY_UNDER_TEST --output json > $QUERY_RESULTS
+    assert_exists $QUERY_RESULTS
+}
+
+#bats test_tags=scope:smoke
+@test "has_expected_number_of_results" {
+    if ![[ -e $QUERY_RESULTS ]]; then skip ; fi
+
+    run bash -c "cat $QUERY_RESULTS | jq -r '. | length'"
+    assert_output $MY_CHECK_COUNT
+}
+
+@test "has_expected_name" {
+    if ![[ -e $QUERY_RESULTS ]]; then skip ; fi
+
+    run bash -c "cat $QUERY_RESULTS | jq -r '.[0].name'"
+    assert_output --partial $MY_TOP_CHECK_NAME
+}
+
+@test "has_expected_topics" {
+    if ![[ -e $QUERY_RESULTS ]]; then skip ; fi
+
+    run bash -c "cat $QUERY_RESULTS | jq -r '.[0].topics'"
+    assert_output --partial $MY_TOP_CHECK_TOPICS
+}
+
+@test "has_expected_compatible_platforms" {
+    if ![[ -e $QUERY_RESULTS ]]; then skip ; fi
+
+    run bash -c "cat $QUERY_RESULTS | jq -r '.[0].compatible_platforms'"
+    assert_output --partial $MY_TOP_CHECK_COMPATIBLE_PLATFORMS
+}
+
+@test "has_expected_targeted_groups" {
+    if ![[ -e $QUERY_RESULTS ]]; then skip ; fi
+
+    run bash -c "cat $QUERY_RESULTS | jq -r '.[0].targeted_groups'"
+    assert_output --partial $MY_TOP_CHECK_TARGETED_GROUPS
+}
+
+@test "has_expected_blocking_group_names" {
+    if ![[ -e $QUERY_RESULTS ]]; then skip ; fi
+
+    run bash -c "cat $QUERY_RESULTS | jq -r '.[0].blocking_group_names'"
+    assert_output --partial $MY_TOP_CHECK_BLOCKING_GROUP_NAMES
+}
+
+@test "has_expected_blocking_enabled" {
+    if ![[ -e $QUERY_RESULTS ]]; then skip ; fi
+
+    run bash -c "cat $QUERY_RESULTS | jq -r '.[0].blocking_enabled'"
+    assert_output --partial $MY_TOP_CHECK_BLOCKING_ENABLED
+}
+
+teardown_file(){
+    rm -f $QUERY_RESULTS
+}

--- a/test/end-to-end/kolide_check_by_id.bats
+++ b/test/end-to-end/kolide_check_by_id.bats
@@ -1,0 +1,31 @@
+# bats file_tags=table:kolide_check, output:check
+
+setup_file() {
+    load "${BATS_TEST_DIRNAME}/_support/globals.bash"
+    define_file_globals
+}
+
+setup() {
+    load "${BATS_TEST_DIRNAME}/_support/extensions.bash"
+    load_helpers
+}
+
+#bats test_tags=scope:smoke
+@test "can_execute_query_via_steampipe" {
+    steampipe query $QUERY_UNDER_TEST --output json > $QUERY_RESULTS
+    assert_exists $QUERY_RESULTS
+}
+
+#bats test_tags=scope:smoke
+@test "has_exactly_one_result" {
+    if ![[ -e $QUERY_RESULTS ]]; then skip ; fi
+
+    run bash -c "cat $QUERY_RESULTS | jq -r '. | length'"
+    assert_output "1"
+}
+
+# Remaining functionality covered in kolide_check.bats
+
+teardown_file(){
+    rm -f $QUERY_RESULTS
+}

--- a/test/end-to-end/kolide_check_by_id.bats
+++ b/test/end-to-end/kolide_check_by_id.bats
@@ -16,16 +16,17 @@ setup() {
     assert_exists $QUERY_RESULTS
 }
 
-#bats test_tags=scope:smoke
-@test "has_exactly_one_result" {
-    if ![[ -e $QUERY_RESULTS ]]; then skip ; fi
+@test "has_no_more_than_one_result" {
+    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
 
     run bash -c "cat $QUERY_RESULTS | jq -r '. | length'"
-    assert_output "1"
+    assert [ "$output" -le "1" ]
 }
 
 # Remaining functionality covered in kolide_check.bats
 
 teardown_file(){
-    rm -f $QUERY_RESULTS
+    if [[ -f $QUERY_RESULTS ]]; then
+        rm -f $QUERY_RESULTS
+    fi
 }

--- a/test/end-to-end/kolide_deprovisioned_person.bats
+++ b/test/end-to-end/kolide_deprovisioned_person.bats
@@ -3,7 +3,12 @@
 setup_file() {
     load "${BATS_TEST_DIRNAME}/_support/globals.bash"
     define_file_globals
-    define_test_results
+
+    define_common_test_results
+
+    if [[ -f $EXPECTED_RESULTS ]]; then
+        load $EXPECTED_RESULTS
+    fi
 }
 
 setup() {
@@ -17,28 +22,31 @@ setup() {
     assert_exists $QUERY_RESULTS
 }
 
-#bats test_tags=scope:smoke
 @test "has_expected_number_of_results" {
-    if ![[ -e $QUERY_RESULTS ]]; then skip ; fi
+    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
 
     run bash -c "cat $QUERY_RESULTS | jq -r '. | length'"
-    assert_output $MY_DEPROVISIONED_PERSON_COUNT
+
+    if [[ -z "$EXPECTED_COUNT" ]]; then assert_output $EXPECTED_COUNT ; else assert [ "$output" -ge "1" ] ; fi
 }
 
 @test "has_expected_name" {
-    if ![[ -e $QUERY_RESULTS ]]; then skip ; fi
+    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
 
     run bash -c "cat $QUERY_RESULTS | jq -r '.[0].name'"
-    assert_output --partial $MY_TOP_DEPROVISIONED_PERSON_NAME
+    if [[ -z "$NAME" ]]; then assert_output $NAME ; else assert_success ; fi
 }
 
-@test "has_expected_email_domain" {
-    if ![[ -e $QUERY_RESULTS ]]; then skip ; fi
+#bats test_tags=exactness:fallback
+@test "has_expected_email" {
+    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
 
     run bash -c "cat $QUERY_RESULTS | jq -r '.[0].email'"
-    assert_output --partial $MY_DEFAULT_EMAIL_DOMAIN
+    if [[ -z "$EMAIL" ]]; then assert_output $EMAIL ; else assert_output --partial $MY_DEFAULT_EMAIL_DOMAIN ; fi
 }
 
 teardown_file(){
-    rm -f $QUERY_RESULTS
+    if [[ -f $QUERY_RESULTS ]]; then
+        rm -f $QUERY_RESULTS
+    fi
 }

--- a/test/end-to-end/kolide_deprovisioned_person.bats
+++ b/test/end-to-end/kolide_deprovisioned_person.bats
@@ -1,0 +1,44 @@
+# bats file_tags=table:kolide_deprovisioned_person, output:deprovisioned_person
+
+setup_file() {
+    load "${BATS_TEST_DIRNAME}/_support/globals.bash"
+    define_file_globals
+    define_test_results
+}
+
+setup() {
+    load "${BATS_TEST_DIRNAME}/_support/extensions.bash"
+    load_helpers
+}
+
+#bats test_tags=scope:smoke
+@test "can_execute_query_via_steampipe" {
+    steampipe query $QUERY_UNDER_TEST --output json > $QUERY_RESULTS
+    assert_exists $QUERY_RESULTS
+}
+
+#bats test_tags=scope:smoke
+@test "has_expected_number_of_results" {
+    if ![[ -e $QUERY_RESULTS ]]; then skip ; fi
+
+    run bash -c "cat $QUERY_RESULTS | jq -r '. | length'"
+    assert_output $MY_DEPROVISIONED_PERSON_COUNT
+}
+
+@test "has_expected_name" {
+    if ![[ -e $QUERY_RESULTS ]]; then skip ; fi
+
+    run bash -c "cat $QUERY_RESULTS | jq -r '.[0].name'"
+    assert_output --partial $MY_TOP_DEPROVISIONED_PERSON_NAME
+}
+
+@test "has_expected_email_domain" {
+    if ![[ -e $QUERY_RESULTS ]]; then skip ; fi
+
+    run bash -c "cat $QUERY_RESULTS | jq -r '.[0].email'"
+    assert_output --partial $MY_DEFAULT_EMAIL_DOMAIN
+}
+
+teardown_file(){
+    rm -f $QUERY_RESULTS
+}

--- a/test/end-to-end/kolide_device.bats
+++ b/test/end-to-end/kolide_device.bats
@@ -3,7 +3,12 @@
 setup_file() {
     load "${BATS_TEST_DIRNAME}/_support/globals.bash"
     define_file_globals
-    define_test_results
+
+    define_common_test_results
+
+    if [[ -f $EXPECTED_RESULTS ]]; then
+        load $EXPECTED_RESULTS
+    fi
 }
 
 setup() {
@@ -17,35 +22,38 @@ setup() {
     assert_exists $QUERY_RESULTS
 }
 
-#bats test_tags=scope:smoke
 @test "has_expected_number_of_results" {
-    if ![[ -e $QUERY_RESULTS ]]; then skip ; fi
+    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
 
     run bash -c "cat $QUERY_RESULTS | jq -r '. | length'"
-    assert_output $MY_DEVICE_COUNT
+
+    if [[ -z "$EXPECTED_COUNT" ]]; then assert_output $EXPECTED_COUNT ; else assert [ "$output" -ge "1" ] ; fi
 }
 
 @test "has_expected_name" {
-    if ![[ -e $QUERY_RESULTS ]]; then skip ; fi
+    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
 
     run bash -c "cat $QUERY_RESULTS | jq -r '.[0].name'"
-    assert_output $MY_TOP_DEVICE_NAME
+    if [[ -z "$NAME" ]]; then assert_output $NAME ; else assert_success ; fi
 }
 
+#bats test_tags=exactness:fuzzy
 @test "has_expected_hardware_model" {
-    if ![[ -e $QUERY_RESULTS ]]; then skip ; fi
+    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
 
     run bash -c "cat $QUERY_RESULTS | jq -r '.[0].hardware_model'"
-    assert_output --partial $MY_TOP_DEVICE_HARDWARE_MODEL
+    if [[ -z "$HARDWARE_MODEL" ]]; then assert_output --partial $HARDWARE_MODEL ; else assert_success ; fi
 }
 
 @test "has_expected_serial" {
-    if ![[ -e $QUERY_RESULTS ]]; then skip; fi
+    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
 
     run bash -c "cat $QUERY_RESULTS | jq -r '.[0].serial'"
-    assert_output $MY_TOP_DEVICE_SERIAL
+    if [[ -z "$SERIAL" ]]; then assert_output $SERIAL ; else assert_success ; fi
 }
 
 teardown_file(){
-    rm -f $QUERY_RESULTS
+    if [[ -f $QUERY_RESULTS ]]; then
+        rm -f $QUERY_RESULTS
+    fi
 }

--- a/test/end-to-end/kolide_device.bats
+++ b/test/end-to-end/kolide_device.bats
@@ -1,0 +1,51 @@
+# bats file_tags=table:kolide_device, output:device
+
+setup_file() {
+    load "${BATS_TEST_DIRNAME}/_support/globals.bash"
+    define_file_globals
+    define_test_results
+}
+
+setup() {
+    load "${BATS_TEST_DIRNAME}/_support/extensions.bash"
+    load_helpers
+}
+
+#bats test_tags=scope:smoke
+@test "can_execute_query_via_steampipe" {
+    steampipe query $QUERY_UNDER_TEST --output json > $QUERY_RESULTS
+    assert_exists $QUERY_RESULTS
+}
+
+#bats test_tags=scope:smoke
+@test "has_expected_number_of_results" {
+    if ![[ -e $QUERY_RESULTS ]]; then skip ; fi
+
+    run bash -c "cat $QUERY_RESULTS | jq -r '. | length'"
+    assert_output $MY_DEVICE_COUNT
+}
+
+@test "has_expected_name" {
+    if ![[ -e $QUERY_RESULTS ]]; then skip ; fi
+
+    run bash -c "cat $QUERY_RESULTS | jq -r '.[0].name'"
+    assert_output $MY_TOP_DEVICE_NAME
+}
+
+@test "has_expected_hardware_model" {
+    if ![[ -e $QUERY_RESULTS ]]; then skip ; fi
+
+    run bash -c "cat $QUERY_RESULTS | jq -r '.[0].hardware_model'"
+    assert_output --partial $MY_TOP_DEVICE_HARDWARE_MODEL
+}
+
+@test "has_expected_serial" {
+    if ![[ -e $QUERY_RESULTS ]]; then skip; fi
+
+    run bash -c "cat $QUERY_RESULTS | jq -r '.[0].serial'"
+    assert_output $MY_TOP_DEVICE_SERIAL
+}
+
+teardown_file(){
+    rm -f $QUERY_RESULTS
+}

--- a/test/end-to-end/kolide_device_by_id.bats
+++ b/test/end-to-end/kolide_device_by_id.bats
@@ -16,16 +16,17 @@ setup() {
     assert_exists $QUERY_RESULTS
 }
 
-#bats test_tags=scope:smoke
-@test "has_exactly_one_result" {
-    if ![[ -e $QUERY_RESULTS ]]; then skip ; fi
+@test "has_no_more_than_one_result" {
+    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
 
     run bash -c "cat $QUERY_RESULTS | jq -r '. | length'"
-    assert_output "1"
+    assert [ "$output" -le "1" ]
 }
 
 # Remaining functionality covered in kolide_device.bats
 
 teardown_file(){
-    rm -f $QUERY_RESULTS
+    if [[ -f $QUERY_RESULTS ]]; then
+        rm -f $QUERY_RESULTS
+    fi
 }

--- a/test/end-to-end/kolide_device_by_id.bats
+++ b/test/end-to-end/kolide_device_by_id.bats
@@ -1,0 +1,31 @@
+# bats file_tags=table:kolide_device, output:device
+
+setup_file() {
+    load "${BATS_TEST_DIRNAME}/_support/globals.bash"
+    define_file_globals
+}
+
+setup() {
+    load "${BATS_TEST_DIRNAME}/_support/extensions.bash"
+    load_helpers
+}
+
+#bats test_tags=scope:smoke
+@test "can_execute_query_via_steampipe" {
+    steampipe query $QUERY_UNDER_TEST --output json > $QUERY_RESULTS
+    assert_exists $QUERY_RESULTS
+}
+
+#bats test_tags=scope:smoke
+@test "has_exactly_one_result" {
+    if ![[ -e $QUERY_RESULTS ]]; then skip ; fi
+
+    run bash -c "cat $QUERY_RESULTS | jq -r '. | length'"
+    assert_output "1"
+}
+
+# Remaining functionality covered in kolide_device.bats
+
+teardown_file(){
+    rm -f $QUERY_RESULTS
+}

--- a/test/end-to-end/kolide_device_group.bats
+++ b/test/end-to-end/kolide_device_group.bats
@@ -2,8 +2,7 @@
 
 setup_file() {
     load "${BATS_TEST_DIRNAME}/_support/globals.bash"
-    define_file_globals
-    define_test_results
+    define_common_test_results
 }
 
 setup() {
@@ -12,10 +11,10 @@ setup() {
 }
 
 # With a Kolide K2 API key, this endpoint returns a 403
-#bats test_tags=scope:smoke
+#bats test_tags=scope:smoke, failing:billing
 @test "query_forbidden_under_billing_plan" {
-    if ![ "$KOLIDE_PLAN" = "K2" ]; then skip; fi
+    if [[ "$MY_KOLIDE_PLAN" != "K2" ]]; then skip; fi
 
     run ! steampipe query $QUERY_UNDER_TEST
-    assert_output --partial "Kolide K2 API Error: 403 Forbidden"
+    assert_output --partial "403"
 }

--- a/test/end-to-end/kolide_device_group.bats
+++ b/test/end-to-end/kolide_device_group.bats
@@ -1,0 +1,21 @@
+# bats file_tags=table:kolide_device_group, output:device_group
+
+setup_file() {
+    load "${BATS_TEST_DIRNAME}/_support/globals.bash"
+    define_file_globals
+    define_test_results
+}
+
+setup() {
+    load "${BATS_TEST_DIRNAME}/_support/extensions.bash"
+    load_helpers
+}
+
+# With a Kolide K2 API key, this endpoint returns a 403
+#bats test_tags=scope:smoke
+@test "query_forbidden_under_billing_plan" {
+    if ![ "$KOLIDE_PLAN" = "K2" ]; then skip; fi
+
+    run ! steampipe query $QUERY_UNDER_TEST
+    assert_output --partial "Kolide K2 API Error: 403 Forbidden"
+}

--- a/test/end-to-end/kolide_device_group_by_id.bats
+++ b/test/end-to-end/kolide_device_group_by_id.bats
@@ -1,15 +1,20 @@
 # bats file_tags=table:kolide_device_group, output:device_group
 
+setup_file() {
+    load "${BATS_TEST_DIRNAME}/_support/globals.bash"
+    define_common_test_results
+}
+
 setup() {
     load "${BATS_TEST_DIRNAME}/_support/extensions.bash"
     load_helpers
 }
 
 # With a Kolide K2 API key, this endpoint returns a 403
-#bats test_tags=scope:smoke
+#bats test_tags=scope:smoke, failing:billing
 @test "query_forbidden_under_billing_plan" {
-    if ![ "$KOLIDE_PLAN" = "K2" ]; then skip; fi
+    if [[ "$MY_KOLIDE_PLAN" != "K2" ]]; then skip; fi
 
-    run ! steampipe query "select id, name from kolide_device_group where id = '12345';"
-    assert_output --partial "Kolide K2 API Error: 403 Forbidden"
+    run ! steampipe query $QUERY_UNDER_TEST
+    assert_output --partial "403"
 }

--- a/test/end-to-end/kolide_device_group_by_id.bats
+++ b/test/end-to-end/kolide_device_group_by_id.bats
@@ -1,0 +1,15 @@
+# bats file_tags=table:kolide_device_group, output:device_group
+
+setup() {
+    load "${BATS_TEST_DIRNAME}/_support/extensions.bash"
+    load_helpers
+}
+
+# With a Kolide K2 API key, this endpoint returns a 403
+#bats test_tags=scope:smoke
+@test "query_forbidden_under_billing_plan" {
+    if ![ "$KOLIDE_PLAN" = "K2" ]; then skip; fi
+
+    run ! steampipe query "select id, name from kolide_device_group where id = '12345';"
+    assert_output --partial "Kolide K2 API Error: 403 Forbidden"
+}

--- a/test/end-to-end/kolide_device_group_device.bats
+++ b/test/end-to-end/kolide_device_group_device.bats
@@ -1,15 +1,20 @@
 # bats file_tags=table:kolide_device_group_device, output:device
 
+setup_file() {
+    load "${BATS_TEST_DIRNAME}/_support/globals.bash"
+    define_common_test_results
+}
+
 setup() {
     load "${BATS_TEST_DIRNAME}/_support/extensions.bash"
     load_helpers
 }
 
 # With a Kolide K2 API key, this endpoint returns a 403
-#bats test_tags=scope:smoke
+#bats test_tags=scope:smoke, failing:billing
 @test "query_forbidden_under_billing_plan" {
-    if ![ "$KOLIDE_PLAN" = "K2" ]; then skip; fi
+    if [[ "$MY_KOLIDE_PLAN" != "K2" ]]; then skip; fi
 
-    run ! steampipe query "select id, name from kolide_device_group order by name desc;"
-    assert_output --partial "Kolide K2 API Error: 403 Forbidden"
+    run ! steampipe query $QUERY_UNDER_TEST
+    assert_output --partial "403"
 }

--- a/test/end-to-end/kolide_device_group_device.bats
+++ b/test/end-to-end/kolide_device_group_device.bats
@@ -1,0 +1,15 @@
+# bats file_tags=table:kolide_device_group_device, output:device
+
+setup() {
+    load "${BATS_TEST_DIRNAME}/_support/extensions.bash"
+    load_helpers
+}
+
+# With a Kolide K2 API key, this endpoint returns a 403
+#bats test_tags=scope:smoke
+@test "query_forbidden_under_billing_plan" {
+    if ![ "$KOLIDE_PLAN" = "K2" ]; then skip; fi
+
+    run ! steampipe query "select id, name from kolide_device_group order by name desc;"
+    assert_output --partial "Kolide K2 API Error: 403 Forbidden"
+}

--- a/test/end-to-end/kolide_device_open_issue.bats
+++ b/test/end-to-end/kolide_device_open_issue.bats
@@ -3,7 +3,12 @@
 setup_file() {
     load "${BATS_TEST_DIRNAME}/_support/globals.bash"
     define_file_globals
-    define_test_results
+
+    define_common_test_results
+
+    if [[ -f $EXPECTED_RESULTS ]]; then
+        load $EXPECTED_RESULTS
+    fi
 }
 
 setup() {
@@ -17,18 +22,56 @@ setup() {
     assert_exists $QUERY_RESULTS
 }
 
-#bats test_tags=scope:smoke
 @test "has_expected_number_of_results" {
-    skip "too volatile"
+    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
+
+    run bash -c "cat $QUERY_RESULTS | jq -r '. | length'"
+
+    if [[ -z "$EXPECTED_COUNT" ]]; then assert_output $EXPECTED_COUNT ; else assert [ "$output" -ge "1" ] ; fi
 }
 
+#bats test_tags=exactness:fuzzy
 @test "has_expected_title" {
-    if ![[ -e $QUERY_RESULTS ]]; then skip ; fi
+    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
 
     run bash -c "cat $QUERY_RESULTS | jq -r '.[0].title'"
-    assert_output --partial $MY_TOP_DEVICE_OPEN_ISSUE_TITLE
+    if [[ -z "$TITLE" ]]; then assert_output --partial $TITLE ; else assert_success ; fi
+}
+
+#bats test_tags=exactness:fuzzy
+@test "has_expected_detected_at" {
+    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
+
+    run bash -c "cat $QUERY_RESULTS | jq -r '.[0].detected_at'"
+    if [[ -z "$DETECTED_AT" ]]; then assert_output --partial $DETECTED_AT ; else assert_success ; fi
+}
+
+#bats test_tags=exactness:fuzzy
+@test "has_expected_blocks_device_at" {
+    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
+
+    run bash -c "cat $QUERY_RESULTS | jq -r '.[0].blocks_device_at'"
+    if [[ -z "$BLOCKS_DEVICE_AT" ]]; then assert_output --partial $BLOCKS_DEVICE_AT ; else assert_success ; fi
+}
+
+#bats test_tags=exactness:fuzzy
+@test "has_expected_resolved_at" {
+    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
+
+    run bash -c "cat $QUERY_RESULTS | jq -r '.[0].resolved_at'"
+    if [[ -z "$RESOLVED_AT" ]]; then assert_output --partial $RESOLVED_AT ; else assert_success ; fi
+}
+
+#bats test_tags=exactness:default
+@test "has_expected_exempted" {
+    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
+
+    run bash -c "cat $QUERY_RESULTS | jq -r '.[0].exempted'"
+    if [[ -z "$EXEMPTED" ]]; then assert_output $EXEMPTED ; else assert_output "false" ; fi
 }
 
 teardown_file(){
-    rm -f $QUERY_RESULTS
+    if [[ -f $QUERY_RESULTS ]]; then
+        rm -f $QUERY_RESULTS
+    fi
 }

--- a/test/end-to-end/kolide_device_open_issue.bats
+++ b/test/end-to-end/kolide_device_open_issue.bats
@@ -1,0 +1,34 @@
+# bats file_tags=table:kolide_device_open_issue, output:issue
+
+setup_file() {
+    load "${BATS_TEST_DIRNAME}/_support/globals.bash"
+    define_file_globals
+    define_test_results
+}
+
+setup() {
+    load "${BATS_TEST_DIRNAME}/_support/extensions.bash"
+    load_helpers
+}
+
+#bats test_tags=scope:smoke
+@test "can_execute_query_via_steampipe" {
+    steampipe query $QUERY_UNDER_TEST --output json > $QUERY_RESULTS
+    assert_exists $QUERY_RESULTS
+}
+
+#bats test_tags=scope:smoke
+@test "has_expected_number_of_results" {
+    skip "too volatile"
+}
+
+@test "has_expected_title" {
+    if ![[ -e $QUERY_RESULTS ]]; then skip ; fi
+
+    run bash -c "cat $QUERY_RESULTS | jq -r '.[0].title'"
+    assert_output --partial $MY_TOP_DEVICE_OPEN_ISSUE_TITLE
+}
+
+teardown_file(){
+    rm -f $QUERY_RESULTS
+}

--- a/test/end-to-end/kolide_issue.bats
+++ b/test/end-to-end/kolide_issue.bats
@@ -1,0 +1,34 @@
+# bats file_tags=table:kolide_issue, output:issue
+
+setup_file() {
+    load "${BATS_TEST_DIRNAME}/_support/globals.bash"
+    define_file_globals
+    define_test_results
+}
+
+setup() {
+    load "${BATS_TEST_DIRNAME}/_support/extensions.bash"
+    load_helpers
+}
+
+#bats test_tags=scope:smoke
+@test "can_execute_query_via_steampipe" {
+    steampipe query $QUERY_UNDER_TEST --output json > $QUERY_RESULTS
+    assert_exists $QUERY_RESULTS
+}
+
+#bats test_tags=scope:smoke
+@test "has_expected_number_of_results" {
+    skip "too volatile"
+}
+
+@test "has_expected_title" {
+    if ![[ -e $QUERY_RESULTS ]]; then skip ; fi
+
+    run bash -c "cat $QUERY_RESULTS | jq -r '.[0].title'"
+    assert_output --partial $MY_TOP_ISSUE_TITLE
+}
+
+teardown_file(){
+    rm -f $QUERY_RESULTS
+}

--- a/test/end-to-end/kolide_issue.bats
+++ b/test/end-to-end/kolide_issue.bats
@@ -3,7 +3,12 @@
 setup_file() {
     load "${BATS_TEST_DIRNAME}/_support/globals.bash"
     define_file_globals
-    define_test_results
+
+    define_common_test_results
+
+    if [[ -f $EXPECTED_RESULTS ]]; then
+        load $EXPECTED_RESULTS
+    fi
 }
 
 setup() {
@@ -17,18 +22,56 @@ setup() {
     assert_exists $QUERY_RESULTS
 }
 
-#bats test_tags=scope:smoke
 @test "has_expected_number_of_results" {
-    skip "too volatile"
+    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
+
+    run bash -c "cat $QUERY_RESULTS | jq -r '. | length'"
+
+    if [[ -z "$EXPECTED_COUNT" ]]; then assert_output $EXPECTED_COUNT ; else assert [ "$output" -ge "1" ] ; fi
 }
 
+#bats test_tags=exactness:fuzzy
 @test "has_expected_title" {
-    if ![[ -e $QUERY_RESULTS ]]; then skip ; fi
+    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
 
     run bash -c "cat $QUERY_RESULTS | jq -r '.[0].title'"
-    assert_output --partial $MY_TOP_ISSUE_TITLE
+    if [[ -z "$TITLE" ]]; then assert_output --partial $TITLE ; else assert_success ; fi
+}
+
+#bats test_tags=exactness:fuzzy
+@test "has_expected_detected_at" {
+    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
+
+    run bash -c "cat $QUERY_RESULTS | jq -r '.[0].detected_at'"
+    if [[ -z "$DETECTED_AT" ]]; then assert_output --partial $DETECTED_AT ; else assert_success ; fi
+}
+
+#bats test_tags=exactness:fuzzy
+@test "has_expected_blocks_device_at" {
+    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
+
+    run bash -c "cat $QUERY_RESULTS | jq -r '.[0].blocks_device_at'"
+    if [[ -z "$BLOCKS_DEVICE_AT" ]]; then assert_output --partial $BLOCKS_DEVICE_AT ; else assert_success ; fi
+}
+
+#bats test_tags=exactness:fuzzy
+@test "has_expected_resolved_at" {
+    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
+
+    run bash -c "cat $QUERY_RESULTS | jq -r '.[0].resolved_at'"
+    if [[ -z "$RESOLVED_AT" ]]; then assert_output --partial $RESOLVED_AT ; else assert_success ; fi
+}
+
+#bats test_tags=exactness:default
+@test "has_expected_exempted" {
+    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
+
+    run bash -c "cat $QUERY_RESULTS | jq -r '.[0].exempted'"
+    if [[ -z "$EXEMPTED" ]]; then assert_output $EXEMPTED ; else assert_output "false" ; fi
 }
 
 teardown_file(){
-    rm -f $QUERY_RESULTS
+    if [[ -f $QUERY_RESULTS ]]; then
+        rm -f $QUERY_RESULTS
+    fi
 }

--- a/test/end-to-end/kolide_issue_by_id.bats
+++ b/test/end-to-end/kolide_issue_by_id.bats
@@ -16,16 +16,17 @@ setup() {
     assert_exists $QUERY_RESULTS
 }
 
-#bats test_tags=scope:smoke
-@test "has_exactly_one_result" {
-    if ![[ -e $QUERY_RESULTS ]]; then skip ; fi
+@test "has_no_more_than_one_result" {
+    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
 
     run bash -c "cat $QUERY_RESULTS | jq -r '. | length'"
-    assert_output "1"
+    assert [ "$output" -le "1" ]
 }
 
 # Remaining functionality covered in kolide_issue.bats
 
 teardown_file(){
-    rm -f $QUERY_RESULTS
+    if [[ -f $QUERY_RESULTS ]]; then
+        rm -f $QUERY_RESULTS
+    fi
 }

--- a/test/end-to-end/kolide_issue_by_id.bats
+++ b/test/end-to-end/kolide_issue_by_id.bats
@@ -1,0 +1,31 @@
+# bats file_tags=table:kolide_issue, output:issue
+
+setup_file() {
+    load "${BATS_TEST_DIRNAME}/_support/globals.bash"
+    define_file_globals
+}
+
+setup() {
+    load "${BATS_TEST_DIRNAME}/_support/extensions.bash"
+    load_helpers
+}
+
+#bats test_tags=scope:smoke
+@test "can_execute_query_via_steampipe" {
+    steampipe query $QUERY_UNDER_TEST --output json > $QUERY_RESULTS
+    assert_exists $QUERY_RESULTS
+}
+
+#bats test_tags=scope:smoke
+@test "has_exactly_one_result" {
+    if ![[ -e $QUERY_RESULTS ]]; then skip ; fi
+
+    run bash -c "cat $QUERY_RESULTS | jq -r '. | length'"
+    assert_output "1"
+}
+
+# Remaining functionality covered in kolide_issue.bats
+
+teardown_file(){
+    rm -f $QUERY_RESULTS
+}

--- a/test/end-to-end/kolide_package.bats
+++ b/test/end-to-end/kolide_package.bats
@@ -1,0 +1,44 @@
+# bats file_tags=table:kolide_package, output:package
+
+setup_file() {
+    load "${BATS_TEST_DIRNAME}/_support/globals.bash"
+    define_file_globals
+    define_test_results
+}
+
+setup() {
+    load "${BATS_TEST_DIRNAME}/_support/extensions.bash"
+    load_helpers
+}
+
+#bats test_tags=scope:smoke
+@test "can_execute_query_via_steampipe" {
+    steampipe query $QUERY_UNDER_TEST --output json > $QUERY_RESULTS
+    assert_exists $QUERY_RESULTS
+}
+
+#bats test_tags=scope:smoke
+@test "has_expected_number_of_results" {
+    if ![[ -e $QUERY_RESULTS ]]; then skip ; fi
+
+    run bash -c "cat $QUERY_RESULTS | jq -r '. | length'"
+    assert_output $MY_PACKAGE_COUNT
+}
+
+@test "has_expected_id" {
+    if ![[ -e $QUERY_RESULTS ]]; then skip ; fi
+
+    run bash -c "cat $QUERY_RESULTS | jq -r '.[0].id'"
+    assert_output --partial $MY_TOP_PACKAGE_ID
+}
+
+@test "has_expected_url" {
+    if ![[ -e $QUERY_RESULTS ]]; then skip ; fi
+
+    run bash -c "cat $QUERY_RESULTS | jq -r '.[0].url'"
+    assert_output --partial $MY_TOP_PACKAGE_URL
+}
+
+teardown_file(){
+    rm -f $QUERY_RESULTS
+}

--- a/test/end-to-end/kolide_package.bats
+++ b/test/end-to-end/kolide_package.bats
@@ -3,7 +3,12 @@
 setup_file() {
     load "${BATS_TEST_DIRNAME}/_support/globals.bash"
     define_file_globals
-    define_test_results
+
+    define_common_test_results
+
+    if [[ -f $EXPECTED_RESULTS ]]; then
+        load $EXPECTED_RESULTS
+    fi
 }
 
 setup() {
@@ -17,28 +22,46 @@ setup() {
     assert_exists $QUERY_RESULTS
 }
 
-#bats test_tags=scope:smoke
 @test "has_expected_number_of_results" {
-    if ![[ -e $QUERY_RESULTS ]]; then skip ; fi
+    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
 
     run bash -c "cat $QUERY_RESULTS | jq -r '. | length'"
-    assert_output $MY_PACKAGE_COUNT
+
+    if [[ -z "$EXPECTED_COUNT" ]]; then assert_output $EXPECTED_COUNT ; else assert [ "$output" -ge "1" ] ; fi
 }
 
 @test "has_expected_id" {
-    if ![[ -e $QUERY_RESULTS ]]; then skip ; fi
+    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
 
     run bash -c "cat $QUERY_RESULTS | jq -r '.[0].id'"
-    assert_output --partial $MY_TOP_PACKAGE_ID
+    if [[ -z "$ID" ]]; then assert_output $ID ; else assert_success ; fi
 }
 
+#bats test_tags=exactness:fuzzy
+@test "has_expected_built_at" {
+    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
+
+    run bash -c "cat $QUERY_RESULTS | jq -r '.[0].built_at'"
+    if [[ -z "$BUILT_AT" ]]; then assert_output --partial $BUILT_AT ; else assert_success ; fi
+}
+
+@test "has_expected_version" {
+    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
+
+    run bash -c "cat $QUERY_RESULTS | jq -r '.[0].version'"
+    if [[ -z "$VERSION" ]]; then assert_output $VERSION ; else assert_success ; fi
+}
+
+
 @test "has_expected_url" {
-    if ![[ -e $QUERY_RESULTS ]]; then skip ; fi
+    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
 
     run bash -c "cat $QUERY_RESULTS | jq -r '.[0].url'"
-    assert_output --partial $MY_TOP_PACKAGE_URL
+    if [[ -z "$URL" ]]; then assert_output $URL ; else assert_success ; fi
 }
 
 teardown_file(){
-    rm -f $QUERY_RESULTS
+    if [[ -f $QUERY_RESULTS ]]; then
+        rm -f $QUERY_RESULTS
+    fi
 }

--- a/test/end-to-end/kolide_package_by_id.bats
+++ b/test/end-to-end/kolide_package_by_id.bats
@@ -16,16 +16,17 @@ setup() {
     assert_exists $QUERY_RESULTS
 }
 
-#bats test_tags=scope:smoke
-@test "has_exactly_one_result" {
-    if ![[ -e $QUERY_RESULTS ]]; then skip ; fi
+@test "has_no_more_than_one_result" {
+    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
 
     run bash -c "cat $QUERY_RESULTS | jq -r '. | length'"
-    assert_output "1"
+    assert [ "$output" -le "1" ]
 }
 
 # Remaining functionality covered in kolide_package.bats
 
 teardown_file(){
-    rm -f $QUERY_RESULTS
+    if [[ -f $QUERY_RESULTS ]]; then
+        rm -f $QUERY_RESULTS
+    fi
 }

--- a/test/end-to-end/kolide_package_by_id.bats
+++ b/test/end-to-end/kolide_package_by_id.bats
@@ -1,0 +1,31 @@
+# bats file_tags=table:kolide_package, output:package
+
+setup_file() {
+    load "${BATS_TEST_DIRNAME}/_support/globals.bash"
+    define_file_globals
+}
+
+setup() {
+    load "${BATS_TEST_DIRNAME}/_support/extensions.bash"
+    load_helpers
+}
+
+#bats test_tags=scope:smoke
+@test "can_execute_query_via_steampipe" {
+    steampipe query $QUERY_UNDER_TEST --output json > $QUERY_RESULTS
+    assert_exists $QUERY_RESULTS
+}
+
+#bats test_tags=scope:smoke
+@test "has_exactly_one_result" {
+    if ![[ -e $QUERY_RESULTS ]]; then skip ; fi
+
+    run bash -c "cat $QUERY_RESULTS | jq -r '. | length'"
+    assert_output "1"
+}
+
+# Remaining functionality covered in kolide_package.bats
+
+teardown_file(){
+    rm -f $QUERY_RESULTS
+}

--- a/test/end-to-end/kolide_person.bats
+++ b/test/end-to-end/kolide_person.bats
@@ -1,0 +1,54 @@
+# bats file_tags=table:kolide_person, output:person
+
+setup_file() {
+    load "${BATS_TEST_DIRNAME}/_support/globals.bash"
+    define_file_globals
+    define_test_results
+}
+
+setup() {
+    load "${BATS_TEST_DIRNAME}/_support/extensions.bash"
+    load_helpers
+}
+
+#bats test_tags=scope:smoke
+@test "can_execute_query_via_steampipe" {
+    steampipe query $QUERY_UNDER_TEST --output json > $QUERY_RESULTS
+    assert_exists $QUERY_RESULTS
+}
+
+#bats test_tags=scope:smoke
+@test "has_expected_number_of_results" {
+    if ![[ -e $QUERY_RESULTS ]]; then skip ; fi
+
+    run bash -c "cat $QUERY_RESULTS | jq -r '. | length'"
+    assert_output $MY_PERSON_COUNT
+}
+
+@test "has_expected_name" {
+    if ![[ -e $QUERY_RESULTS ]]; then skip ; fi
+    if [ "$MY_PERSON_COUNT" == "0" ]; then skip "no results"; fi
+
+    run bash -c "cat $QUERY_RESULTS | jq -r '.[0].name'"
+    assert_output --partial $MY_TOP_PERSON_NAME
+}
+
+@test "has_expected_email_domain" {
+    if ![[ -e $QUERY_RESULTS ]]; then skip ; fi
+    if [ "$MY_PERSON_COUNT" == "0" ]; then skip "no results"; fi
+
+    run bash -c "cat $QUERY_RESULTS | jq -r '.[0].email'"
+    assert_output --partial $MY_DEFAULT_EMAIL_DOMAIN
+}
+
+@test "has_expected_registered_devices" {
+    if ![[ -e $QUERY_RESULTS ]]; then skip ; fi
+    if [ "$MY_PERSON_COUNT" == "0" ]; then skip "no results"; fi
+
+    run bash -c "cat $QUERY_RESULTS | jq -r '.[0].has_registered_device'"
+    assert_output $MY_TOP_PERSON_REGISTERED_DEVICE
+}
+
+teardown_file(){
+    rm -f $QUERY_RESULTS
+}

--- a/test/end-to-end/kolide_person.bats
+++ b/test/end-to-end/kolide_person.bats
@@ -3,7 +3,12 @@
 setup_file() {
     load "${BATS_TEST_DIRNAME}/_support/globals.bash"
     define_file_globals
-    define_test_results
+
+    define_common_test_results
+
+    if [[ -f $EXPECTED_RESULTS ]]; then
+        load $EXPECTED_RESULTS
+    fi
 }
 
 setup() {
@@ -17,38 +22,41 @@ setup() {
     assert_exists $QUERY_RESULTS
 }
 
-#bats test_tags=scope:smoke
 @test "has_expected_number_of_results" {
-    if ![[ -e $QUERY_RESULTS ]]; then skip ; fi
+    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
 
     run bash -c "cat $QUERY_RESULTS | jq -r '. | length'"
-    assert_output $MY_PERSON_COUNT
+
+    if [[ -z "$EXPECTED_COUNT" ]]; then assert_output $EXPECTED_COUNT ; else assert [ "$output" -ge "1" ] ; fi
 }
 
 @test "has_expected_name" {
-    if ![[ -e $QUERY_RESULTS ]]; then skip ; fi
-    if [ "$MY_PERSON_COUNT" == "0" ]; then skip "no results"; fi
+    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
 
     run bash -c "cat $QUERY_RESULTS | jq -r '.[0].name'"
-    assert_output --partial $MY_TOP_PERSON_NAME
+    if [[ -z "$NAME" ]]; then assert_output $NAME ; else assert_success ; fi
 }
 
-@test "has_expected_email_domain" {
-    if ![[ -e $QUERY_RESULTS ]]; then skip ; fi
-    if [ "$MY_PERSON_COUNT" == "0" ]; then skip "no results"; fi
+#bats test_tags=exactness:fallback
+@test "has_expected_email" {
+    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
 
     run bash -c "cat $QUERY_RESULTS | jq -r '.[0].email'"
-    assert_output --partial $MY_DEFAULT_EMAIL_DOMAIN
+    if [[ -z "$EMAIL" ]]; then assert_output $EMAIL ; else assert_output --partial $MY_DEFAULT_EMAIL_DOMAIN ; fi
 }
 
-@test "has_expected_registered_devices" {
-    if ![[ -e $QUERY_RESULTS ]]; then skip ; fi
-    if [ "$MY_PERSON_COUNT" == "0" ]; then skip "no results"; fi
+#bats test_tags=exactness:default
+@test "has_expected_has_registered_device" {
+    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
 
     run bash -c "cat $QUERY_RESULTS | jq -r '.[0].has_registered_device'"
-    assert_output $MY_TOP_PERSON_REGISTERED_DEVICE
+    if [[ -z "$HAS_REGISTERED_DEVICE" ]]; then assert_output $HAS_REGISTERED_DEVICE ; else assert_output "false" ; fi
 }
 
+
+
 teardown_file(){
-    rm -f $QUERY_RESULTS
+    if [[ -f $QUERY_RESULTS ]]; then
+        rm -f $QUERY_RESULTS
+    fi
 }

--- a/test/end-to-end/kolide_person_by_id.bats
+++ b/test/end-to-end/kolide_person_by_id.bats
@@ -3,7 +3,6 @@
 setup_file() {
     load "${BATS_TEST_DIRNAME}/_support/globals.bash"
     define_file_globals
-    define_test_results
 }
 
 setup() {
@@ -17,17 +16,17 @@ setup() {
     assert_exists $QUERY_RESULTS
 }
 
-#bats test_tags=scope:smoke
-@test "has_exactly_one_result" {
-    if ![[ -e $QUERY_RESULTS ]]; then skip ; fi
-    if [ "$MY_PERSON_COUNT" == "0" ]; then skip "no results"; fi
+@test "has_no_more_than_one_result" {
+    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
 
     run bash -c "cat $QUERY_RESULTS | jq -r '. | length'"
-    assert_output "1"
+    assert [ "$output" -le "1" ]
 }
 
 # Remaining functionality covered in kolide_person.bats
 
 teardown_file(){
-    rm -f $QUERY_RESULTS
+    if [[ -f $QUERY_RESULTS ]]; then
+        rm -f $QUERY_RESULTS
+    fi
 }

--- a/test/end-to-end/kolide_person_by_id.bats
+++ b/test/end-to-end/kolide_person_by_id.bats
@@ -1,0 +1,33 @@
+# bats file_tags=table:kolide_person, output:person
+
+setup_file() {
+    load "${BATS_TEST_DIRNAME}/_support/globals.bash"
+    define_file_globals
+    define_test_results
+}
+
+setup() {
+    load "${BATS_TEST_DIRNAME}/_support/extensions.bash"
+    load_helpers
+}
+
+#bats test_tags=scope:smoke
+@test "can_execute_query_via_steampipe" {
+    steampipe query $QUERY_UNDER_TEST --output json > $QUERY_RESULTS
+    assert_exists $QUERY_RESULTS
+}
+
+#bats test_tags=scope:smoke
+@test "has_exactly_one_result" {
+    if ![[ -e $QUERY_RESULTS ]]; then skip ; fi
+    if [ "$MY_PERSON_COUNT" == "0" ]; then skip "no results"; fi
+
+    run bash -c "cat $QUERY_RESULTS | jq -r '. | length'"
+    assert_output "1"
+}
+
+# Remaining functionality covered in kolide_person.bats
+
+teardown_file(){
+    rm -f $QUERY_RESULTS
+}

--- a/test/end-to-end/kolide_person_group.bats
+++ b/test/end-to-end/kolide_person_group.bats
@@ -1,15 +1,20 @@
 # bats file_tags=table:kolide_person_group, output:person_group
 
+setup_file() {
+    load "${BATS_TEST_DIRNAME}/_support/globals.bash"
+    define_common_test_results
+}
+
 setup() {
     load "${BATS_TEST_DIRNAME}/_support/extensions.bash"
     load_helpers
 }
 
 # With a Kolide K2 API key, this endpoint returns a 403
-#bats test_tags=scope:smoke
+#bats test_tags=scope:smoke, failing:billing
 @test "query_forbidden_under_billing_plan" {
-    if ![ "$KOLIDE_PLAN" = "K2" ]; then skip; fi
+    if [[ "$MY_KOLIDE_PLAN" != "K2" ]]; then skip; fi
 
-    run ! steampipe query "select id, name from kolide_person_group order by name desc;"
-    assert_output --partial "Kolide K2 API Error: 403 Forbidden"
+    run ! steampipe query $QUERY_UNDER_TEST
+    assert_output --partial "403"
 }

--- a/test/end-to-end/kolide_person_group.bats
+++ b/test/end-to-end/kolide_person_group.bats
@@ -1,0 +1,15 @@
+# bats file_tags=table:kolide_person_group, output:person_group
+
+setup() {
+    load "${BATS_TEST_DIRNAME}/_support/extensions.bash"
+    load_helpers
+}
+
+# With a Kolide K2 API key, this endpoint returns a 403
+#bats test_tags=scope:smoke
+@test "query_forbidden_under_billing_plan" {
+    if ![ "$KOLIDE_PLAN" = "K2" ]; then skip; fi
+
+    run ! steampipe query "select id, name from kolide_person_group order by name desc;"
+    assert_output --partial "Kolide K2 API Error: 403 Forbidden"
+}

--- a/test/end-to-end/kolide_person_group_by_id.bats
+++ b/test/end-to-end/kolide_person_group_by_id.bats
@@ -1,0 +1,15 @@
+# bats file_tags=table:kolide_person_group, output:person_group
+
+setup() {
+    load "${BATS_TEST_DIRNAME}/_support/extensions.bash"
+    load_helpers
+}
+
+# With a Kolide K2 API key, this endpoint returns a 403
+#bats test_tags=scope:smoke
+@test "query_forbidden_under_billing_plan" {
+    if ![ "$KOLIDE_PLAN" = "K2" ]; then skip; fi
+
+    run ! steampipe query "select id, name from kolide_person_group where id = '12345';"
+    assert_output --partial "Kolide K2 API Error: 403 Forbidden"
+}

--- a/test/end-to-end/kolide_person_group_by_id.bats
+++ b/test/end-to-end/kolide_person_group_by_id.bats
@@ -1,15 +1,20 @@
 # bats file_tags=table:kolide_person_group, output:person_group
 
+setup_file() {
+    load "${BATS_TEST_DIRNAME}/_support/globals.bash"
+    define_common_test_results
+}
+
 setup() {
     load "${BATS_TEST_DIRNAME}/_support/extensions.bash"
     load_helpers
 }
 
 # With a Kolide K2 API key, this endpoint returns a 403
-#bats test_tags=scope:smoke
+#bats test_tags=scope:smoke, failing:billing
 @test "query_forbidden_under_billing_plan" {
-    if ![ "$KOLIDE_PLAN" = "K2" ]; then skip; fi
+    if [[ "$MY_KOLIDE_PLAN" != "K2" ]]; then skip; fi
 
-    run ! steampipe query "select id, name from kolide_person_group where id = '12345';"
-    assert_output --partial "Kolide K2 API Error: 403 Forbidden"
+    run ! steampipe query $QUERY_UNDER_TEST
+    assert_output --partial "403"
 }

--- a/test/end-to-end/kolide_person_open_issue.bats
+++ b/test/end-to-end/kolide_person_open_issue.bats
@@ -3,7 +3,12 @@
 setup_file() {
     load "${BATS_TEST_DIRNAME}/_support/globals.bash"
     define_file_globals
-    define_test_results
+
+    define_common_test_results
+
+    if [[ -f $EXPECTED_RESULTS ]]; then
+        load $EXPECTED_RESULTS
+    fi
 }
 
 setup() {
@@ -17,19 +22,56 @@ setup() {
     assert_exists $QUERY_RESULTS
 }
 
-#bats test_tags=scope:smoke
 @test "has_expected_number_of_results" {
-    skip "too volatile"
+    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
+
+    run bash -c "cat $QUERY_RESULTS | jq -r '. | length'"
+
+    if [[ -z "$EXPECTED_COUNT" ]]; then assert_output $EXPECTED_COUNT ; else assert [ "$output" -ge "1" ] ; fi
 }
 
+#bats test_tags=exactness:fuzzy
 @test "has_expected_title" {
-    if ![[ -e $QUERY_RESULTS ]]; then skip ; fi
-    if [ "$MY_PERSON_OPEN_ISSUE_COUNT" == "0" ]; then skip "no results"; fi
+    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
 
     run bash -c "cat $QUERY_RESULTS | jq -r '.[0].title'"
-    assert_output --partial $MY_TOP_PERSON_OPEN_ISSUE_TITLE
+    if [[ -z "$TITLE" ]]; then assert_output --partial $TITLE ; else assert_success ; fi
+}
+
+#bats test_tags=exactness:fuzzy
+@test "has_expected_detected_at" {
+    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
+
+    run bash -c "cat $QUERY_RESULTS | jq -r '.[0].detected_at'"
+    if [[ -z "$DETECTED_AT" ]]; then assert_output --partial $DETECTED_AT ; else assert_success ; fi
+}
+
+#bats test_tags=exactness:fuzzy
+@test "has_expected_blocks_device_at" {
+    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
+
+    run bash -c "cat $QUERY_RESULTS | jq -r '.[0].blocks_device_at'"
+    if [[ -z "$BLOCKS_DEVICE_AT" ]]; then assert_output --partial $BLOCKS_DEVICE_AT ; else assert_success ; fi
+}
+
+#bats test_tags=exactness:fuzzy
+@test "has_expected_resolved_at" {
+    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
+
+    run bash -c "cat $QUERY_RESULTS | jq -r '.[0].resolved_at'"
+    if [[ -z "$RESOLVED_AT" ]]; then assert_output --partial $RESOLVED_AT ; else assert_success ; fi
+}
+
+#bats test_tags=exactness:default
+@test "has_expected_exempted" {
+    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
+
+    run bash -c "cat $QUERY_RESULTS | jq -r '.[0].exempted'"
+    if [[ -z "$EXEMPTED" ]]; then assert_output $EXEMPTED ; else assert_output "false" ; fi
 }
 
 teardown_file(){
-    rm -f $QUERY_RESULTS
+    if [[ -f $QUERY_RESULTS ]]; then
+        rm -f $QUERY_RESULTS
+    fi
 }

--- a/test/end-to-end/kolide_person_open_issue.bats
+++ b/test/end-to-end/kolide_person_open_issue.bats
@@ -1,0 +1,35 @@
+# bats file_tags=table:kolide_person_open_issue, output:issue
+
+setup_file() {
+    load "${BATS_TEST_DIRNAME}/_support/globals.bash"
+    define_file_globals
+    define_test_results
+}
+
+setup() {
+    load "${BATS_TEST_DIRNAME}/_support/extensions.bash"
+    load_helpers
+}
+
+#bats test_tags=scope:smoke
+@test "can_execute_query_via_steampipe" {
+    steampipe query $QUERY_UNDER_TEST --output json > $QUERY_RESULTS
+    assert_exists $QUERY_RESULTS
+}
+
+#bats test_tags=scope:smoke
+@test "has_expected_number_of_results" {
+    skip "too volatile"
+}
+
+@test "has_expected_title" {
+    if ![[ -e $QUERY_RESULTS ]]; then skip ; fi
+    if [ "$MY_PERSON_OPEN_ISSUE_COUNT" == "0" ]; then skip "no results"; fi
+
+    run bash -c "cat $QUERY_RESULTS | jq -r '.[0].title'"
+    assert_output --partial $MY_TOP_PERSON_OPEN_ISSUE_TITLE
+}
+
+teardown_file(){
+    rm -f $QUERY_RESULTS
+}

--- a/test/end-to-end/kolide_person_registered_device.bats
+++ b/test/end-to-end/kolide_person_registered_device.bats
@@ -3,7 +3,12 @@
 setup_file() {
     load "${BATS_TEST_DIRNAME}/_support/globals.bash"
     define_file_globals
-    define_test_results
+
+    define_common_test_results
+
+    if [[ -f $EXPECTED_RESULTS ]]; then
+        load $EXPECTED_RESULTS
+    fi
 }
 
 setup() {
@@ -17,38 +22,38 @@ setup() {
     assert_exists $QUERY_RESULTS
 }
 
-#bats test_tags=scope:smoke
 @test "has_expected_number_of_results" {
-    if ![[ -e $QUERY_RESULTS ]]; then skip ; fi
+    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
 
     run bash -c "cat $QUERY_RESULTS | jq -r '. | length'"
-    assert_output $MY_PERSON_REGISTERED_DEVICE_COUNT
+
+    if [[ -z "$EXPECTED_COUNT" ]]; then assert_output $EXPECTED_COUNT ; else assert [ "$output" -ge "1" ] ; fi
 }
 
 @test "has_expected_name" {
-    if ![[ -e $QUERY_RESULTS ]]; then skip ; fi
-    if [ "$MY_PERSON_REGISTERED_DEVICE_COUNT" == "0" ]; then skip "no results"; fi
+    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
 
     run bash -c "cat $QUERY_RESULTS | jq -r '.[0].name'"
-    assert_output --partial $MY_TOP_PERSON_REGISTERED_DEVICE_NAME
+    if [[ -z "$NAME" ]]; then assert_output $NAME ; else assert_success ; fi
 }
 
+#bats test_tags=exactness:fuzzy
 @test "has_expected_hardware_model" {
-    if ![[ -e $QUERY_RESULTS ]]; then skip ; fi
-    if [ "$MY_PERSON_REGISTERED_DEVICE_COUNT" == "0" ]; then skip "no results"; fi
+    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
 
     run bash -c "cat $QUERY_RESULTS | jq -r '.[0].hardware_model'"
-    assert_output --partial $MY_TOP_PERSON_REGISTERED_DEVICE_HARDWARE_MODEL
+    if [[ -z "$HARDWARE_MODEL" ]]; then assert_output --partial $HARDWARE_MODEL ; else assert_success ; fi
 }
 
 @test "has_expected_serial" {
-    if ![[ -e $QUERY_RESULTS ]]; then skip; fi
-    if [ "$MY_PERSON_REGISTERED_DEVICE_COUNT" == "0" ]; then skip "no results"; fi
+    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
 
     run bash -c "cat $QUERY_RESULTS | jq -r '.[0].serial'"
-    assert_output $MY_TOP_PERSON_REGISTERED_DEVICE_SERIAL
+    if [[ -z "$SERIAL" ]]; then assert_output $SERIAL ; else assert_success ; fi
 }
 
 teardown_file(){
-    rm -f $QUERY_RESULTS
+    if [[ -f $QUERY_RESULTS ]]; then
+        rm -f $QUERY_RESULTS
+    fi
 }

--- a/test/end-to-end/kolide_person_registered_device.bats
+++ b/test/end-to-end/kolide_person_registered_device.bats
@@ -1,0 +1,54 @@
+# bats file_tags=table:kolide_registered_device, output:device
+
+setup_file() {
+    load "${BATS_TEST_DIRNAME}/_support/globals.bash"
+    define_file_globals
+    define_test_results
+}
+
+setup() {
+    load "${BATS_TEST_DIRNAME}/_support/extensions.bash"
+    load_helpers
+}
+
+#bats test_tags=scope:smoke
+@test "can_execute_query_via_steampipe" {
+    steampipe query $QUERY_UNDER_TEST --output json > $QUERY_RESULTS
+    assert_exists $QUERY_RESULTS
+}
+
+#bats test_tags=scope:smoke
+@test "has_expected_number_of_results" {
+    if ![[ -e $QUERY_RESULTS ]]; then skip ; fi
+
+    run bash -c "cat $QUERY_RESULTS | jq -r '. | length'"
+    assert_output $MY_PERSON_REGISTERED_DEVICE_COUNT
+}
+
+@test "has_expected_name" {
+    if ![[ -e $QUERY_RESULTS ]]; then skip ; fi
+    if [ "$MY_PERSON_REGISTERED_DEVICE_COUNT" == "0" ]; then skip "no results"; fi
+
+    run bash -c "cat $QUERY_RESULTS | jq -r '.[0].name'"
+    assert_output --partial $MY_TOP_PERSON_REGISTERED_DEVICE_NAME
+}
+
+@test "has_expected_hardware_model" {
+    if ![[ -e $QUERY_RESULTS ]]; then skip ; fi
+    if [ "$MY_PERSON_REGISTERED_DEVICE_COUNT" == "0" ]; then skip "no results"; fi
+
+    run bash -c "cat $QUERY_RESULTS | jq -r '.[0].hardware_model'"
+    assert_output --partial $MY_TOP_PERSON_REGISTERED_DEVICE_HARDWARE_MODEL
+}
+
+@test "has_expected_serial" {
+    if ![[ -e $QUERY_RESULTS ]]; then skip; fi
+    if [ "$MY_PERSON_REGISTERED_DEVICE_COUNT" == "0" ]; then skip "no results"; fi
+
+    run bash -c "cat $QUERY_RESULTS | jq -r '.[0].serial'"
+    assert_output $MY_TOP_PERSON_REGISTERED_DEVICE_SERIAL
+}
+
+teardown_file(){
+    rm -f $QUERY_RESULTS
+}


### PR DESCRIPTION
## Description

Devised a mechanism for simple end-to-end tests, with some flexibility for other users to modifiy according to their own Kolide data (in `test/end-to-end/_support/global.bash`). At the moment these tests assume you are workin on macOS, however we intend to bring them into a GitHub Action. 

Tests can be run per file or, using BATS tag filtering, per table or output type or restricted to smoke tests. Running the whole test suite takes around two minutes on my Kolide data set

## Related Tickets & Documents

None

## Steps to Verify

1. Install BATS and the BATS extensions, i.e. via Homebrew
2. Execute the test suite, `bats test/end-to-end/kolide_*.bats --filter-tags scope:smoke`