### PR TITLE
fix: ensure person open issues is unmarshalled

### DIFF
--- a/test/end-to-end/_query/kolide_unprocessable_entity.sql
+++ b/test/end-to-end/_query/kolide_unprocessable_entity.sql
@@ -1,0 +1,9 @@
+select
+  title,
+  person_id
+from
+  kolide_person_open_issue
+where
+  person_id = '1607'
+order by
+  detected_at asc;

--- a/test/end-to-end/_results/kolide_unprocessable_entity.bash
+++ b/test/end-to-end/_results/kolide_unprocessable_entity.bash
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+define_test_results(){
+    # Unexpected behaviour in Kolide API under K2; this endpoint returns an empty list
+    export EXPECTED_COUNT="0"
+    # export TITLE=""
+    # export DETECTED_AT=""
+    # export BLOCKS_DEVICE_AT=""
+    # export RESOLVED_AT=""
+    # export EXEMPTED=""
+}

--- a/test/end-to-end/kolide_unprocessable_entity.bats
+++ b/test/end-to-end/kolide_unprocessable_entity.bats
@@ -1,0 +1,54 @@
+# bats file_tags=table:kolide_person_open_issue, output:issue
+
+setup_file() {
+    load "${BATS_TEST_DIRNAME}/_support/globals.bash"
+    define_file_globals
+
+    define_common_test_results
+
+    if [[ -f $EXPECTED_RESULTS ]]; then
+        load $EXPECTED_RESULTS
+    fi
+}
+
+setup() {
+    load "${BATS_TEST_DIRNAME}/_support/extensions.bash"
+    load_helpers
+}
+
+# Regression test for https://github.com/grendel-consulting/steampipe-plugin-kolide/issues/129
+#bats test_tags=scope:regression
+@test "can_execute_query_via_steampipe" {
+    steampipe query $QUERY_UNDER_TEST --output json > $QUERY_RESULTS
+    assert_exists $QUERY_RESULTS
+}
+
+@test "has_expected_number_of_results" {
+    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
+
+    run bash -c "cat $QUERY_RESULTS | jq -r '. | length'"
+
+    if [[ -z "$EXPECTED_COUNT" ]]; then assert_output $EXPECTED_COUNT ; else assert [ "$output" -ge "1" ] ; fi
+}
+
+#bats test_tags=exactness:fuzzy
+@test "has_expected_title" {
+    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
+
+    run bash -c "cat $QUERY_RESULTS | jq -r '.[0].title'"
+    if [[ -z "$TITLE" ]]; then assert_output --partial $TITLE ; else assert_success ; fi
+}
+
+#bats test_tags=exactness:fuzzy
+@test "has_expected_person_id" {
+    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
+
+    run bash -c "cat $QUERY_RESULTS | jq -r '.[0].detected_at'"
+    if [[ -z "$DETECTED_AT" ]]; then assert_output --partial $DETECTED_AT ; else assert_success ; fi
+}
+
+teardown_file(){
+    if [[ -f $QUERY_RESULTS ]]; then
+        rm -f $QUERY_RESULTS
+    fi
+}


### PR DESCRIPTION
## Description

With the `/person/{personId}/open_issues` endpoint (and only that endpoint) we need to provide `personId` as a path parameter but it is not in the returned structure; this was causing an issue whereby Steampipe needed it in the KeyColumns to ensure inclusion in the WHERE clause but the `serializeSearches()` function needed it to not to be there

## Related Tickets & Documents

Closes #129 

## Steps to Verify

No error is returned from running `select * from kolide_person_open_issues where person_id = <id>`