### PR TITLE
feat: implement GET /registration_requests and /registration_requests/{id}

### DIFF
--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -43,8 +43,8 @@ using the interactive API documentation at https://kolideapi.readme.io/reference
 | GET    | /exemption_requests/{id}                                   | #37                |    ? |    ? |   Ok |
 | PATCH  | /exemption_requests/{id}                                   | :no_entry_sign:    |      |      |      |
 | PUT    | /exemption_requests/{id}                                   | :no_entry_sign:    |      |      |      |
-| GET    | /registration_requests                                     | #38                |    ? |    ? |   Ok |
-| GET    | /registration_requests/{id}                                | #39                |    ? |    ? |   Ok |
+| GET    | /registration_requests                                     | :question:         |    ? |    ? |   Ok |
+| GET    | /registration_requests/{id}                                | :question:         |    ? |    ? |   Ok |
 | PATCH  | /registration_requests/{id}                                | :no_entry_sign:    |      |      |      |
 | PUT    | /registration_requests/{id}                                | :no_entry_sign:    |      |      |      |
 | GET    | /reporting/tables/{tableName}/table_records                | #42                |    ? |    ? | [^1] |

--- a/docs/tables/kolide_registration_request.md
+++ b/docs/tables/kolide_registration_request.md
@@ -1,0 +1,51 @@
+# Table: kolide_registration_request
+
+Lists the registration requests made when attempting to register a device with Kolide. These can be approved or denied by admins.
+
+## Examples
+
+### Basic info
+
+```sql
+select
+  id,
+  status,
+  requested_at,
+  requester_message,
+  requester_id,
+  device_id
+from
+  kolide_registration_request;
+```
+
+### List all unresolved requests
+
+```sql
+select
+  id,
+  status,
+  requested_at,
+  requester_message,
+  requester_id,
+  device_id
+from
+  kolide_registration_request
+where
+  status != 'approved';
+```
+
+### List all recent requests
+
+```sql
+select
+  id,
+  status,
+  requested_at,
+  requester_message,
+  requester_id,
+  device_id
+from
+  kolide_registration_request
+where
+  requested_at > date_trunc('day', current_date) - interval '4 weeks';
+```

--- a/kolide/client/registration_requests.go
+++ b/kolide/client/registration_requests.go
@@ -1,0 +1,31 @@
+package kolide_client
+
+import "time"
+
+type RegistrationRequestListResponse struct {
+	RegistrationRequests []RegistrationRequest `json:"data"`
+	Pagination           Pagination            `json:"pagination"`
+}
+type RegistrationRequest struct {
+	Id                   string               `json:"id"`
+	Status               string               `json:"status"`
+	RequesterMessage     string               `json:"requester_message,omitempty"`
+	InternalDenialNote   string               `json:"internal_denial_note,omitempty"`
+	RequestedAt          time.Time            `json:"requested_at,omitempty"`
+	EndUserDenialNote    string               `json:"end_user_denial_note,omitempty"`
+	RequesterInformation RequesterInformation `json:"requester_information,omitempty"`
+	DeviceInformation    DeviceInformation    `json:"device_information,omitempty"`
+}
+
+type RequesterInformation struct {
+	// Whilst the Kolide API readme entry references this as a "string", the returned value encountered during implementation MAY BE an "int"
+	Identifier int32 `json:"identifier,omitempty"`
+}
+
+func (c *Client) GetRegistrationRequests(cursor string, limit int32, searches ...Search) (interface{}, error) {
+	return c.fetchCollection("/registration_request/", cursor, limit, searches, new(RegistrationRequestListResponse))
+}
+
+func (c *Client) GetRegistrationRequestById(id string) (interface{}, error) {
+	return c.fetchResource("/registration_request/", id, new(RegistrationRequest))
+}

--- a/kolide/plugin.go
+++ b/kolide/plugin.go
@@ -39,6 +39,7 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 			"kolide_person_group":             tableKolidePersonGroup(ctx),
 			"kolide_person_open_issue":        tableKolidePersonOpenIssue(ctx),
 			"kolide_person_registered_device": tableKolidePersonRegisteredDevice(ctx),
+			"kolide_registration_request":     tableKolideRegistrationRequest(ctx),
 		},
 	}
 	return p

--- a/kolide/table_kolide_registration_request.go
+++ b/kolide/table_kolide_registration_request.go
@@ -1,0 +1,66 @@
+package kolide
+
+import (
+	"context"
+
+	kolide "github.com/grendel-consulting/steampipe-plugin-kolide/kolide/client"
+	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+)
+
+//// TABLE DEFINITION
+
+func tableKolideRegistrationRequest(_ context.Context) *plugin.Table {
+	return &plugin.Table{
+		Name:        "kolide_registration_request",
+		Description: "Created when someone requests admin approval to register a device with Kolide. Registration requests can be approved or denied by admins",
+		Columns: []*plugin.Column{
+			// Filterable "top" columns
+			{Name: "id", Description: "Canonical identifier for this registration request.", Type: proto.ColumnType_STRING},
+			{Name: "status", Description: "Current status of this registration request; one of: pending, approved or denied", Type: proto.ColumnType_STRING},
+			{Name: "requester_message", Description: "Any message the person provided when requesting approval for this registration.", Type: proto.ColumnType_STRING},
+			{Name: "requested_at", Description: "When this registration approval was requested.", Type: proto.ColumnType_TIMESTAMP},
+			// Other columns
+			{Name: "end_user_denial_note", Description: "Any explanation the admin provided for the requester when denying this request, for internal documentation. It is meant to be shown to the requester. It will be blank if the registration has not been denied.", Type: proto.ColumnType_STRING},
+			{Name: "internal_denial_note", Description: "Any internal explanation the admin provided when denying this request, for internal documentation. It is not shown to the requester. It will be blank if the registration has not been denied.", Type: proto.ColumnType_STRING},
+			{Name: "requester_id", Description: "Canonical identifier for the person who requested this registration.", Type: proto.ColumnType_STRING, Transform: transform.FromField("RequesterInformation.Identifier")},
+			{Name: "device_id", Description: "Canonical identifier for the device the person is trying to register.", Type: proto.ColumnType_STRING, Transform: transform.FromField("DeviceInformation.Identifier")},
+			// Steampipe standard columns
+			{Name: "title", Description: "Display name for this registration request.", Type: proto.ColumnType_STRING, Transform: transform.FromField("DeviceInformation.Identifier")},
+		},
+		List: &plugin.ListConfig{
+			KeyColumns: []*plugin.KeyColumn{
+				// Using Kolide API query feature, can be combined with AND (and OR)
+				{Name: "status", Require: plugin.Optional, Operators: []string{"=", "~~"}},
+				{Name: "requested_at", Require: plugin.Optional, Operators: []string{"=", ">", "<"}},
+				{Name: "requester_message", Require: plugin.Optional, Operators: []string{"=", "~~"}},
+			},
+			Hydrate: listRegistrationRequests,
+		},
+		Get: &plugin.GetConfig{
+			KeyColumns: plugin.SingleColumn("id"),
+			Hydrate:    getRegistrationRequest,
+		},
+	}
+}
+
+//// LIST FUNCTION
+
+func listRegistrationRequests(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	var visitor ListPredicate = func(client *kolide.Client, cursor string, limit int32, searches ...kolide.Search) (interface{}, error) {
+		return client.GetRegistrationRequests(cursor, limit, searches...)
+	}
+
+	return listAnything(ctx, d, h, "kolide_registration_request.listRegistrationRequests", visitor, "RegistrationRequests")
+}
+
+//// GET FUNCTION
+
+func getRegistrationRequest(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	var visitor GetPredicate = func(client *kolide.Client, id string) (interface{}, error) {
+		return client.GetRegistrationRequestById(id)
+	}
+
+	return getAnything(ctx, d, h, "kolide_registration_request.getRegistrationRequest", "id", visitor)
+}

--- a/test/end-to-end/_query/kolide_registration_request.sql
+++ b/test/end-to-end/_query/kolide_registration_request.sql
@@ -1,0 +1,11 @@
+select
+  id,
+  status,
+  requested_at,
+  requester_message,
+  requester_id,
+  device_id
+from
+  kolide_registration_request
+order by
+  id asc;

--- a/test/end-to-end/_query/kolide_registration_request_by_id.sql
+++ b/test/end-to-end/_query/kolide_registration_request_by_id.sql
@@ -1,0 +1,11 @@
+select
+  id,
+  status,
+  requested_at,
+  requester_message,
+  requester_id,
+  device_id
+from
+  kolide_registration_request
+where
+  id = '12345';

--- a/test/end-to-end/_results/kolide_registration_request.bash
+++ b/test/end-to-end/_results/kolide_registration_request.bash
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+define_test_results(){
+    export EXPECTED_COUNT="0"
+    # export ID=""
+    # export STATUS=""
+    # export REQUESTED_AT=""
+    # export REQUESTER_MESSAGE=""
+    # export REQUESTER_ID=""
+    # export DEVICE_ID=""
+}

--- a/test/end-to-end/kolide_admin_user.bats
+++ b/test/end-to-end/kolide_admin_user.bats
@@ -23,52 +23,38 @@ setup() {
 }
 
 @test "has_expected_number_of_results" {
-    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
-
-    run bash -c "cat $QUERY_RESULTS | jq -r '. | length'"
+    run bash -c "cat $QUERY_RESULTS | jq -r '.rows | length'"
 
     if [[ -z "$EXPECTED_COUNT" ]]; then assert_output $EXPECTED_COUNT ; else assert [ "$output" -ge "1" ] ; fi
 }
 
 @test "has_expected_first_name" {
-    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
-
-    run bash -c "cat $QUERY_RESULTS | jq -r '.[0].first_name'"
+    run bash -c "cat $QUERY_RESULTS | jq -r '.rows.[0].first_name'"
     if [[ -z "$FIRST_NAME" ]]; then assert_output $FIRST_NAME ; else assert_success ; fi
 }
 
 @test "has_expected_last_name" {
-    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
-
-    run bash -c "cat $QUERY_RESULTS | jq -r '.[0].last_name'"
+    run bash -c "cat $QUERY_RESULTS | jq -r '.rows.[0].last_name'"
     if [[ -z "$LAST_NAME" ]]; then assert_output $LAST_NAME ; else assert_success ; fi
 }
 
 #bats test_tags=exactness:fallback
 @test "has_expected_email" {
-    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
-
-    run bash -c "cat $QUERY_RESULTS | jq -r '.[0].email'"
+    run bash -c "cat $QUERY_RESULTS | jq -r '.rows.[0].email'"
     if [[ -z "$EMAIL" ]]; then assert_output $EMAIL ; else assert_output --partial $MY_DEFAULT_EMAIL_DOMAIN ; fi
 }
 
 #bats test_tags=exactness:default
 @test "has_expected_access" {
-    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
-
-    run bash -c "cat $QUERY_RESULTS | jq -r '.[0].access'"
+    run bash -c "cat $QUERY_RESULTS | jq -r '.rows.[0].access'"
     if [[ -z "$ACCESS" ]]; then assert_output $ACCESS ; else assert_output "full" ; fi
 }
 
 #bats test_tags=exactness:fuzzy
 @test "has_expected_created_at" {
-    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
-
-    run bash -c "cat $QUERY_RESULTS | jq -r '.[0].created_at'"
+    run bash -c "cat $QUERY_RESULTS | jq -r '.rows.[0].created_at'"
     if [[ -z "$CREATED_AT" ]]; then assert_output --partial $CREATED_AT ; else assert_success ; fi
 }
-
-
 
 teardown_file(){
     if [[ -f $QUERY_RESULTS ]]; then

--- a/test/end-to-end/kolide_admin_user_by_id.bats
+++ b/test/end-to-end/kolide_admin_user_by_id.bats
@@ -17,9 +17,7 @@ setup() {
 }
 
 @test "has_no_more_than_one_result" {
-    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
-
-    run bash -c "cat $QUERY_RESULTS | jq -r '. | length'"
+    run bash -c "cat $QUERY_RESULTS | jq -r '.rows | length'"
     assert [ "$output" -le "1" ]
 }
 

--- a/test/end-to-end/kolide_audit_log.bats
+++ b/test/end-to-end/kolide_audit_log.bats
@@ -23,34 +23,26 @@ setup() {
 }
 
 @test "has_expected_number_of_results" {
-    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
-
-    run bash -c "cat $QUERY_RESULTS | jq -r '. | length'"
+    run bash -c "cat $QUERY_RESULTS | jq -r '.rows | length'"
 
     if [[ -z "$EXPECTED_COUNT" ]]; then assert_output $EXPECTED_COUNT ; else assert [ "$output" -ge "1" ] ; fi
 }
 
 #bats test_tags=exactness:fuzzy
 @test "has_expected_timestamp" {
-    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
-
-    run bash -c "cat $QUERY_RESULTS | jq -r '.[0].timestamp'"
+    run bash -c "cat $QUERY_RESULTS | jq -r '.rows.[0].timestamp'"
     if [[ -z "$TIMESTAMP" ]]; then assert_output --partial $TIMESTAMP ; else assert_success ; fi
 }
 
 #bats test_tags=exactness:fuzzy
 @test "has_expected_description" {
-    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
-
-    run bash -c "cat $QUERY_RESULTS | jq -r '.[0].description'"
+    run bash -c "cat $QUERY_RESULTS | jq -r '.rows.[0].description'"
     if [[ -z "$DESCRIPTION" ]]; then assert_output --partial $DESCRIPTION ; else assert_success ; fi
 }
 
 #bats test_tags=exactness:fuzzy
 @test "has_expected_actor_name" {
-    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
-
-    run bash -c "cat $QUERY_RESULTS | jq -r '.[0].actor_name'"
+    run bash -c "cat $QUERY_RESULTS | jq -r '.rows.[0].actor_name'"
     if [[ -z "$ACTOR_NAME" ]]; then assert_output --partial $ACTOR_NAME ; else assert_success ; fi
 }
 

--- a/test/end-to-end/kolide_audit_log_by_id.bats
+++ b/test/end-to-end/kolide_audit_log_by_id.bats
@@ -17,9 +17,7 @@ setup() {
 }
 
 @test "has_no_more_than_one_result" {
-    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
-
-    run bash -c "cat $QUERY_RESULTS | jq -r '. | length'"
+    run bash -c "cat $QUERY_RESULTS | jq -r '.rows | length'"
     assert [ "$output" -le "1" ]
 }
 

--- a/test/end-to-end/kolide_check.bats
+++ b/test/end-to-end/kolide_check.bats
@@ -23,64 +23,48 @@ setup() {
 }
 
 @test "has_expected_number_of_results" {
-    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
-
-    run bash -c "cat $QUERY_RESULTS | jq -r '. | length'"
+    run bash -c "cat $QUERY_RESULTS | jq -r '.rows | length'"
 
     if [[ -z "$EXPECTED_COUNT" ]]; then assert_output $EXPECTED_COUNT ; else assert [ "$output" -ge "1" ] ; fi
 }
 
 @test "has_expected_id" {
-    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
-
-    run bash -c "cat $QUERY_RESULTS | jq -r '.[0].id'"
+    run bash -c "cat $QUERY_RESULTS | jq -r '.rows.[0].id'"
     if [[ -z "$ID" ]]; then assert_output $ID ; else assert_success ; fi
 }
 
 @test "has_expected_name" {
-    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
-
-    run bash -c "cat $QUERY_RESULTS | jq -r '.[0].name'"
+    run bash -c "cat $QUERY_RESULTS | jq -r '.rows.[0].name'"
     if [[ -z "$NAME" ]]; then assert_output $NAME ; else assert_success ; fi
 }
 
 #bats test_tags=exactness:fuzzy
 @test "has_expected_topics" {
-    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
-
-    run bash -c "cat $QUERY_RESULTS | jq -r '.[0].topics'"
+    run bash -c "cat $QUERY_RESULTS | jq -r '.rows.[0].topics'"
     if [[ -z "$TOPICS" ]]; then assert_output --partial $TOPICS ; else assert_success ; fi
 }
 
 #bats test_tags=exactness:fuzzy
 @test "has_expected_compatible_platforms" {
-    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
-
-    run bash -c "cat $QUERY_RESULTS | jq -r '.[0].compatible_platforms'"
+    run bash -c "cat $QUERY_RESULTS | jq -r '.rows.[0].compatible_platforms'"
     if [[ -z "$COMPATIBLE_PLATFORMS" ]]; then assert_output --partial $COMPATIBLE_PLATFORMS ; else assert_success ; fi
 }
 
 #bats test_tags=exactness:fuzzy
 @test "has_expected_targeted_groups" {
-    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
-
-    run bash -c "cat $QUERY_RESULTS | jq -r '.[0].targeted_groups'"
+    run bash -c "cat $QUERY_RESULTS | jq -r '.rows.[0].targeted_groups'"
     if [[ -z "$TARGETED_GROUPS" ]]; then assert_output --partial $TARGETED_GROUPS ; else assert_success ; fi
 }
 
 #bats test_tags=exactness:fuzzy
 @test "has_expected_blocking_group_names" {
-    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
-
-    run bash -c "cat $QUERY_RESULTS | jq -r '.[0].blocking_group_names'"
+    run bash -c "cat $QUERY_RESULTS | jq -r '.rows.[0].blocking_group_names'"
     if [[ -z "$BLOCKING_GROUP_NAMES" ]]; then assert_output --partial $BLOCKING_GROUP_NAMES ; else assert_success ; fi
 }
 
 #bats test_tags=exactness:default
 @test "has_expected_blocking_enabled" {
-    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
-
-    run bash -c "cat $QUERY_RESULTS | jq -r '.[0].blocking_enabled'"
+    run bash -c "cat $QUERY_RESULTS | jq -r '.rows.[0].blocking_enabled'"
     if [[ -z "$BLOCKING_ENABLED" ]]; then assert_output $BLOCKING_ENABLED ; else assert_output "false" ; fi
 }
 

--- a/test/end-to-end/kolide_check_by_id.bats
+++ b/test/end-to-end/kolide_check_by_id.bats
@@ -17,9 +17,7 @@ setup() {
 }
 
 @test "has_no_more_than_one_result" {
-    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
-
-    run bash -c "cat $QUERY_RESULTS | jq -r '. | length'"
+    run bash -c "cat $QUERY_RESULTS | jq -r '.rows | length'"
     assert [ "$output" -le "1" ]
 }
 

--- a/test/end-to-end/kolide_deprovisioned_person.bats
+++ b/test/end-to-end/kolide_deprovisioned_person.bats
@@ -23,25 +23,19 @@ setup() {
 }
 
 @test "has_expected_number_of_results" {
-    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
-
-    run bash -c "cat $QUERY_RESULTS | jq -r '. | length'"
+    run bash -c "cat $QUERY_RESULTS | jq -r '.rowss | length'"
 
     if [[ -z "$EXPECTED_COUNT" ]]; then assert_output $EXPECTED_COUNT ; else assert [ "$output" -ge "1" ] ; fi
 }
 
 @test "has_expected_name" {
-    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
-
-    run bash -c "cat $QUERY_RESULTS | jq -r '.[0].name'"
+    run bash -c "cat $QUERY_RESULTS | jq -r '.rows.[0].name'"
     if [[ -z "$NAME" ]]; then assert_output $NAME ; else assert_success ; fi
 }
 
 #bats test_tags=exactness:fallback
 @test "has_expected_email" {
-    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
-
-    run bash -c "cat $QUERY_RESULTS | jq -r '.[0].email'"
+    run bash -c "cat $QUERY_RESULTS | jq -r '.rows.[0].email'"
     if [[ -z "$EMAIL" ]]; then assert_output $EMAIL ; else assert_output --partial $MY_DEFAULT_EMAIL_DOMAIN ; fi
 }
 

--- a/test/end-to-end/kolide_deprovisioned_person.bats
+++ b/test/end-to-end/kolide_deprovisioned_person.bats
@@ -23,7 +23,7 @@ setup() {
 }
 
 @test "has_expected_number_of_results" {
-    run bash -c "cat $QUERY_RESULTS | jq -r '.rowss | length'"
+    run bash -c "cat $QUERY_RESULTS | jq -r '.rows | length'"
 
     if [[ -z "$EXPECTED_COUNT" ]]; then assert_output $EXPECTED_COUNT ; else assert [ "$output" -ge "1" ] ; fi
 }

--- a/test/end-to-end/kolide_device.bats
+++ b/test/end-to-end/kolide_device.bats
@@ -23,32 +23,24 @@ setup() {
 }
 
 @test "has_expected_number_of_results" {
-    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
-
-    run bash -c "cat $QUERY_RESULTS | jq -r '. | length'"
+    run bash -c "cat $QUERY_RESULTS | jq -r '.rows | length'"
 
     if [[ -z "$EXPECTED_COUNT" ]]; then assert_output $EXPECTED_COUNT ; else assert [ "$output" -ge "1" ] ; fi
 }
 
 @test "has_expected_name" {
-    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
-
-    run bash -c "cat $QUERY_RESULTS | jq -r '.[0].name'"
+    run bash -c "cat $QUERY_RESULTS | jq -r '.rows.[0].name'"
     if [[ -z "$NAME" ]]; then assert_output $NAME ; else assert_success ; fi
 }
 
 #bats test_tags=exactness:fuzzy
 @test "has_expected_hardware_model" {
-    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
-
-    run bash -c "cat $QUERY_RESULTS | jq -r '.[0].hardware_model'"
+    run bash -c "cat $QUERY_RESULTS | jq -r '.rows.[0].hardware_model'"
     if [[ -z "$HARDWARE_MODEL" ]]; then assert_output --partial $HARDWARE_MODEL ; else assert_success ; fi
 }
 
 @test "has_expected_serial" {
-    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
-
-    run bash -c "cat $QUERY_RESULTS | jq -r '.[0].serial'"
+    run bash -c "cat $QUERY_RESULTS | jq -r '.rows.[0].serial'"
     if [[ -z "$SERIAL" ]]; then assert_output $SERIAL ; else assert_success ; fi
 }
 

--- a/test/end-to-end/kolide_device_by_id.bats
+++ b/test/end-to-end/kolide_device_by_id.bats
@@ -17,9 +17,7 @@ setup() {
 }
 
 @test "has_no_more_than_one_result" {
-    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
-
-    run bash -c "cat $QUERY_RESULTS | jq -r '. | length'"
+    run bash -c "cat $QUERY_RESULTS | jq -r '.rows | length'"
     assert [ "$output" -le "1" ]
 }
 

--- a/test/end-to-end/kolide_device_open_issue.bats
+++ b/test/end-to-end/kolide_device_open_issue.bats
@@ -23,50 +23,38 @@ setup() {
 }
 
 @test "has_expected_number_of_results" {
-    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
-
-    run bash -c "cat $QUERY_RESULTS | jq -r '. | length'"
+    run bash -c "cat $QUERY_RESULTS | jq -r '.rows | length'"
 
     if [[ -z "$EXPECTED_COUNT" ]]; then assert_output $EXPECTED_COUNT ; else assert [ "$output" -ge "1" ] ; fi
 }
 
 #bats test_tags=exactness:fuzzy
 @test "has_expected_title" {
-    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
-
-    run bash -c "cat $QUERY_RESULTS | jq -r '.[0].title'"
+    run bash -c "cat $QUERY_RESULTS | jq -r '.rows.[0].title'"
     if [[ -z "$TITLE" ]]; then assert_output --partial $TITLE ; else assert_success ; fi
 }
 
 #bats test_tags=exactness:fuzzy
 @test "has_expected_detected_at" {
-    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
-
-    run bash -c "cat $QUERY_RESULTS | jq -r '.[0].detected_at'"
+    run bash -c "cat $QUERY_RESULTS | jq -r '.rows.[0].detected_at'"
     if [[ -z "$DETECTED_AT" ]]; then assert_output --partial $DETECTED_AT ; else assert_success ; fi
 }
 
 #bats test_tags=exactness:fuzzy
 @test "has_expected_blocks_device_at" {
-    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
-
-    run bash -c "cat $QUERY_RESULTS | jq -r '.[0].blocks_device_at'"
+    run bash -c "cat $QUERY_RESULTS | jq -r '.rows.[0].blocks_device_at'"
     if [[ -z "$BLOCKS_DEVICE_AT" ]]; then assert_output --partial $BLOCKS_DEVICE_AT ; else assert_success ; fi
 }
 
 #bats test_tags=exactness:fuzzy
 @test "has_expected_resolved_at" {
-    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
-
-    run bash -c "cat $QUERY_RESULTS | jq -r '.[0].resolved_at'"
+    run bash -c "cat $QUERY_RESULTS | jq -r '.rows.[0].resolved_at'"
     if [[ -z "$RESOLVED_AT" ]]; then assert_output --partial $RESOLVED_AT ; else assert_success ; fi
 }
 
 #bats test_tags=exactness:default
 @test "has_expected_exempted" {
-    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
-
-    run bash -c "cat $QUERY_RESULTS | jq -r '.[0].exempted'"
+    run bash -c "cat $QUERY_RESULTS | jq -r '.rows.[0].exempted'"
     if [[ -z "$EXEMPTED" ]]; then assert_output $EXEMPTED ; else assert_output "false" ; fi
 }
 

--- a/test/end-to-end/kolide_issue.bats
+++ b/test/end-to-end/kolide_issue.bats
@@ -23,55 +23,43 @@ setup() {
 }
 
 @test "has_expected_number_of_results" {
-    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
-
-    run bash -c "cat $QUERY_RESULTS | jq -r '. | length'"
+    run bash -c "cat $QUERY_RESULTS | jq -r '.rows | length'"
 
     if [[ -z "$EXPECTED_COUNT" ]]; then assert_output $EXPECTED_COUNT ; else assert [ "$output" -ge "1" ] ; fi
 }
 
 #bats test_tags=exactness:fuzzy
 @test "has_expected_title" {
-    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
-
-    run bash -c "cat $QUERY_RESULTS | jq -r '.[0].title'"
+    run bash -c "cat $QUERY_RESULTS | jq -r '.rows.[0].title'"
     if [[ -z "$TITLE" ]]; then assert_output --partial $TITLE ; else assert_success ; fi
 }
 
 #bats test_tags=exactness:fuzzy
 @test "has_expected_detected_at" {
-    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
-
-    run bash -c "cat $QUERY_RESULTS | jq -r '.[0].detected_at'"
+    run bash -c "cat $QUERY_RESULTS | jq -r '.rows.[0].detected_at'"
     if [[ -z "$DETECTED_AT" ]]; then assert_output --partial $DETECTED_AT ; else assert_success ; fi
 }
 
 #bats test_tags=exactness:fuzzy
 @test "has_expected_blocks_device_at" {
-    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
-
-    run bash -c "cat $QUERY_RESULTS | jq -r '.[0].blocks_device_at'"
+    run bash -c "cat $QUERY_RESULTS | jq -r '.rows.[0].blocks_device_at'"
     if [[ -z "$BLOCKS_DEVICE_AT" ]]; then assert_output --partial $BLOCKS_DEVICE_AT ; else assert_success ; fi
 }
 
 #bats test_tags=exactness:fuzzy
 @test "has_expected_resolved_at" {
-    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
-
-    run bash -c "cat $QUERY_RESULTS | jq -r '.[0].resolved_at'"
+    run bash -c "cat $QUERY_RESULTS | jq -r '.rows.[0].resolved_at'"
     if [[ -z "$RESOLVED_AT" ]]; then assert_output --partial $RESOLVED_AT ; else assert_success ; fi
 }
 
 #bats test_tags=exactness:default
 @test "has_expected_exempted" {
-    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
-
-    run bash -c "cat $QUERY_RESULTS | jq -r '.[0].exempted'"
+    run bash -c "cat $QUERY_RESULTS | jq -r '.rows.[0].exempted'"
     if [[ -z "$EXEMPTED" ]]; then assert_output $EXEMPTED ; else assert_output "false" ; fi
 }
 
-teardown_file(){
-    if [[ -f $QUERY_RESULTS ]]; then
-        rm -f $QUERY_RESULTS
-    fi
-}
+# teardown_file(){
+#     if [[ -f $QUERY_RESULTS ]]; then
+#         rm -f $QUERY_RESULTS
+#     fi
+# }

--- a/test/end-to-end/kolide_issue_by_id.bats
+++ b/test/end-to-end/kolide_issue_by_id.bats
@@ -17,9 +17,7 @@ setup() {
 }
 
 @test "has_no_more_than_one_result" {
-    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
-
-    run bash -c "cat $QUERY_RESULTS | jq -r '. | length'"
+    run bash -c "cat $QUERY_RESULTS | jq -r '.rows | length'"
     assert [ "$output" -le "1" ]
 }
 

--- a/test/end-to-end/kolide_package.bats
+++ b/test/end-to-end/kolide_package.bats
@@ -23,40 +23,30 @@ setup() {
 }
 
 @test "has_expected_number_of_results" {
-    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
-
-    run bash -c "cat $QUERY_RESULTS | jq -r '. | length'"
+    run bash -c "cat $QUERY_RESULTS | jq -r '.rows | length'"
 
     if [[ -z "$EXPECTED_COUNT" ]]; then assert_output $EXPECTED_COUNT ; else assert [ "$output" -ge "1" ] ; fi
 }
 
 @test "has_expected_id" {
-    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
-
-    run bash -c "cat $QUERY_RESULTS | jq -r '.[0].id'"
+    run bash -c "cat $QUERY_RESULTS | jq -r '.rows.[0].id'"
     if [[ -z "$ID" ]]; then assert_output $ID ; else assert_success ; fi
 }
 
 #bats test_tags=exactness:fuzzy
 @test "has_expected_built_at" {
-    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
-
-    run bash -c "cat $QUERY_RESULTS | jq -r '.[0].built_at'"
+    run bash -c "cat $QUERY_RESULTS | jq -r '.rows.[0].built_at'"
     if [[ -z "$BUILT_AT" ]]; then assert_output --partial $BUILT_AT ; else assert_success ; fi
 }
 
 @test "has_expected_version" {
-    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
-
-    run bash -c "cat $QUERY_RESULTS | jq -r '.[0].version'"
+    run bash -c "cat $QUERY_RESULTS | jq -r '.rows.[0].version'"
     if [[ -z "$VERSION" ]]; then assert_output $VERSION ; else assert_success ; fi
 }
 
 
 @test "has_expected_url" {
-    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
-
-    run bash -c "cat $QUERY_RESULTS | jq -r '.[0].url'"
+    run bash -c "cat $QUERY_RESULTS | jq -r '.rows.[0].url'"
     if [[ -z "$URL" ]]; then assert_output $URL ; else assert_success ; fi
 }
 

--- a/test/end-to-end/kolide_package_by_id.bats
+++ b/test/end-to-end/kolide_package_by_id.bats
@@ -17,9 +17,7 @@ setup() {
 }
 
 @test "has_no_more_than_one_result" {
-    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
-
-    run bash -c "cat $QUERY_RESULTS | jq -r '. | length'"
+    run bash -c "cat $QUERY_RESULTS | jq -r '.rows | length'"
     assert [ "$output" -le "1" ]
 }
 

--- a/test/end-to-end/kolide_person.bats
+++ b/test/end-to-end/kolide_person.bats
@@ -23,37 +23,27 @@ setup() {
 }
 
 @test "has_expected_number_of_results" {
-    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
-
-    run bash -c "cat $QUERY_RESULTS | jq -r '. | length'"
+    run bash -c "cat $QUERY_RESULTS | jq -r '.rows | length'"
 
     if [[ -z "$EXPECTED_COUNT" ]]; then assert_output $EXPECTED_COUNT ; else assert [ "$output" -ge "1" ] ; fi
 }
 
 @test "has_expected_name" {
-    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
-
-    run bash -c "cat $QUERY_RESULTS | jq -r '.[0].name'"
+    run bash -c "cat $QUERY_RESULTS | jq -r '.rows.[0].name'"
     if [[ -z "$NAME" ]]; then assert_output $NAME ; else assert_success ; fi
 }
 
 #bats test_tags=exactness:fallback
 @test "has_expected_email" {
-    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
-
-    run bash -c "cat $QUERY_RESULTS | jq -r '.[0].email'"
+    run bash -c "cat $QUERY_RESULTS | jq -r '.rows.[0].email'"
     if [[ -z "$EMAIL" ]]; then assert_output $EMAIL ; else assert_output --partial $MY_DEFAULT_EMAIL_DOMAIN ; fi
 }
 
 #bats test_tags=exactness:default
 @test "has_expected_has_registered_device" {
-    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
-
-    run bash -c "cat $QUERY_RESULTS | jq -r '.[0].has_registered_device'"
+    run bash -c "cat $QUERY_RESULTS | jq -r '.rows.[0].has_registered_device'"
     if [[ -z "$HAS_REGISTERED_DEVICE" ]]; then assert_output $HAS_REGISTERED_DEVICE ; else assert_output "false" ; fi
 }
-
-
 
 teardown_file(){
     if [[ -f $QUERY_RESULTS ]]; then

--- a/test/end-to-end/kolide_person_by_id.bats
+++ b/test/end-to-end/kolide_person_by_id.bats
@@ -17,9 +17,7 @@ setup() {
 }
 
 @test "has_no_more_than_one_result" {
-    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
-
-    run bash -c "cat $QUERY_RESULTS | jq -r '. | length'"
+    run bash -c "cat $QUERY_RESULTS | jq -r '.rows | length'"
     assert [ "$output" -le "1" ]
 }
 

--- a/test/end-to-end/kolide_person_open_issue.bats
+++ b/test/end-to-end/kolide_person_open_issue.bats
@@ -23,50 +23,38 @@ setup() {
 }
 
 @test "has_expected_number_of_results" {
-    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
-
-    run bash -c "cat $QUERY_RESULTS | jq -r '. | length'"
+    run bash -c "cat $QUERY_RESULTS | jq -r '.rows | length'"
 
     if [[ -z "$EXPECTED_COUNT" ]]; then assert_output $EXPECTED_COUNT ; else assert [ "$output" -ge "1" ] ; fi
 }
 
 #bats test_tags=exactness:fuzzy
 @test "has_expected_title" {
-    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
-
-    run bash -c "cat $QUERY_RESULTS | jq -r '.[0].title'"
+    run bash -c "cat $QUERY_RESULTS | jq -r '.rows.[0].title'"
     if [[ -z "$TITLE" ]]; then assert_output --partial $TITLE ; else assert_success ; fi
 }
 
 #bats test_tags=exactness:fuzzy
 @test "has_expected_detected_at" {
-    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
-
-    run bash -c "cat $QUERY_RESULTS | jq -r '.[0].detected_at'"
+    run bash -c "cat $QUERY_RESULTS | jq -r '.rows.[0].detected_at'"
     if [[ -z "$DETECTED_AT" ]]; then assert_output --partial $DETECTED_AT ; else assert_success ; fi
 }
 
 #bats test_tags=exactness:fuzzy
 @test "has_expected_blocks_device_at" {
-    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
-
-    run bash -c "cat $QUERY_RESULTS | jq -r '.[0].blocks_device_at'"
+    run bash -c "cat $QUERY_RESULTS | jq -r '.rows.[0].blocks_device_at'"
     if [[ -z "$BLOCKS_DEVICE_AT" ]]; then assert_output --partial $BLOCKS_DEVICE_AT ; else assert_success ; fi
 }
 
 #bats test_tags=exactness:fuzzy
 @test "has_expected_resolved_at" {
-    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
-
-    run bash -c "cat $QUERY_RESULTS | jq -r '.[0].resolved_at'"
+    run bash -c "cat $QUERY_RESULTS | jq -r '.rows.[0].resolved_at'"
     if [[ -z "$RESOLVED_AT" ]]; then assert_output --partial $RESOLVED_AT ; else assert_success ; fi
 }
 
 #bats test_tags=exactness:default
 @test "has_expected_exempted" {
-    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
-
-    run bash -c "cat $QUERY_RESULTS | jq -r '.[0].exempted'"
+    run bash -c "cat $QUERY_RESULTS | jq -r '.rows.[0].exempted'"
     if [[ -z "$EXEMPTED" ]]; then assert_output $EXEMPTED ; else assert_output "false" ; fi
 }
 

--- a/test/end-to-end/kolide_person_registered_device.bats
+++ b/test/end-to-end/kolide_person_registered_device.bats
@@ -23,32 +23,24 @@ setup() {
 }
 
 @test "has_expected_number_of_results" {
-    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
-
-    run bash -c "cat $QUERY_RESULTS | jq -r '. | length'"
+    run bash -c "cat $QUERY_RESULTS | jq -r '.rows | length'"
 
     if [[ -z "$EXPECTED_COUNT" ]]; then assert_output $EXPECTED_COUNT ; else assert [ "$output" -ge "1" ] ; fi
 }
 
 @test "has_expected_name" {
-    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
-
-    run bash -c "cat $QUERY_RESULTS | jq -r '.[0].name'"
+    run bash -c "cat $QUERY_RESULTS | jq -r '.rows.[0].name'"
     if [[ -z "$NAME" ]]; then assert_output $NAME ; else assert_success ; fi
 }
 
 #bats test_tags=exactness:fuzzy
 @test "has_expected_hardware_model" {
-    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
-
-    run bash -c "cat $QUERY_RESULTS | jq -r '.[0].hardware_model'"
+    run bash -c "cat $QUERY_RESULTS | jq -r '.rows.[0].hardware_model'"
     if [[ -z "$HARDWARE_MODEL" ]]; then assert_output --partial $HARDWARE_MODEL ; else assert_success ; fi
 }
 
 @test "has_expected_serial" {
-    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
-
-    run bash -c "cat $QUERY_RESULTS | jq -r '.[0].serial'"
+    run bash -c "cat $QUERY_RESULTS | jq -r '.rows.[0].serial'"
     if [[ -z "$SERIAL" ]]; then assert_output $SERIAL ; else assert_success ; fi
 }
 

--- a/test/end-to-end/kolide_registration_request.bats
+++ b/test/end-to-end/kolide_registration_request.bats
@@ -1,0 +1,69 @@
+# bats file_tags=table:kolide_registration_request, output:registration_request
+
+setup_file() {
+    load "${BATS_TEST_DIRNAME}/_support/globals.bash"
+    define_file_globals
+
+    define_common_test_results
+
+    if [[ -f $EXPECTED_RESULTS ]]; then
+        load $EXPECTED_RESULTS
+    fi
+}
+
+setup() {
+    load "${BATS_TEST_DIRNAME}/_support/extensions.bash"
+    load_helpers
+}
+
+#bats test_tags=scope:smoke
+@test "can_execute_query_via_steampipe" {
+    steampipe query $QUERY_UNDER_TEST --output json > $QUERY_RESULTS
+    assert_exists $QUERY_RESULTS
+}
+
+@test "has_expected_number_of_results" {
+    run bash -c "cat $QUERY_RESULTS | jq -r '.rows | length'"
+
+    if [[ -z "$EXPECTED_COUNT" ]]; then assert_output $EXPECTED_COUNT ; else assert [ "$output" -ge "1" ] ; fi
+}
+
+@test "has_expected_id" {
+    run bash -c "cat $QUERY_RESULTS | jq -r '.rows.[0].id'"
+    if [[ -z "$ID" ]]; then assert_output $ID ; else assert_success ; fi
+}
+
+@test "has_expected_status" {
+    run bash -c "cat $QUERY_RESULTS | jq -r '.rows.[0].status'"
+    if [[ -z "$STATUS" ]]; then assert_output --partial $STATUS ; else assert_success ; fi
+}
+
+#bats test_tags=exactness:fuzzy
+@test "has_expected_requested_at" {
+    run bash -c "cat $QUERY_RESULTS | jq -r '.rows.[0].requested_at'"
+    if [[ -z "$REQUESTED_AT" ]]; then assert_output $REQUESTED_AT ; else assert_success ; fi
+}
+
+#bats test_tags=exactness:fuzzy
+@test "has_expected_requester_message" {
+    run bash -c "cat $QUERY_RESULTS | jq -r '.rows.[0].requester_message'"
+    if [[ -z "$REQUESTER_MESSAGE" ]]; then assert_output --partial $REQUESTER_MESSAGE ; else assert_success ; fi
+}
+
+#bats test_tags=exactness:fuzzy
+@test "has_expected_requester_id" {
+    run bash -c "cat $QUERY_RESULTS | jq -r '.rows.[0].requester_id'"
+    if [[ -z "$REQUESTER_ID" ]]; then assert_output --partial $REQUESTER_ID ; else assert_success ; fi
+}
+
+#bats test_tags=exactness:fuzzy
+@test "has_expected_device_id" {
+    run bash -c "cat $QUERY_RESULTS | jq -r '.rows.[0].device_id'"
+    if [[ -z "$DEVICE_ID" ]]; then assert_output --partial $DEVICE_ID ; else assert_success ; fi
+}
+
+teardown_file(){
+    if [[ -f $QUERY_RESULTS ]]; then
+        rm -f $QUERY_RESULTS
+    fi
+}

--- a/test/end-to-end/kolide_registration_request_by_id.bats
+++ b/test/end-to-end/kolide_registration_request_by_id.bats
@@ -1,0 +1,30 @@
+# bats file_tags=table:kolide_registration_request, output:registration_request
+
+setup_file() {
+    load "${BATS_TEST_DIRNAME}/_support/globals.bash"
+    define_file_globals
+}
+
+setup() {
+    load "${BATS_TEST_DIRNAME}/_support/extensions.bash"
+    load_helpers
+}
+
+#bats test_tags=scope:smoke
+@test "can_execute_query_via_steampipe" {
+    steampipe query $QUERY_UNDER_TEST --output json > $QUERY_RESULTS
+    assert_exists $QUERY_RESULTS
+}
+
+@test "has_no_more_than_one_result" {
+    run bash -c "cat $QUERY_RESULTS | jq -r '.rows | length'"
+    assert [ "$output" -le "1" ]
+}
+
+# Remaining functionality covered in kolide_registration_request.bats
+
+teardown_file(){
+    if [[ -f $QUERY_RESULTS ]]; then
+        rm -f $QUERY_RESULTS
+    fi
+}

--- a/test/end-to-end/kolide_unprocessable_entity.bats
+++ b/test/end-to-end/kolide_unprocessable_entity.bats
@@ -24,26 +24,20 @@ setup() {
 }
 
 @test "has_expected_number_of_results" {
-    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
-
-    run bash -c "cat $QUERY_RESULTS | jq -r '. | length'"
+    run bash -c "cat $QUERY_RESULTS | jq -r '.rows | length'"
 
     if [[ -z "$EXPECTED_COUNT" ]]; then assert_output $EXPECTED_COUNT ; else assert [ "$output" -ge "1" ] ; fi
 }
 
 #bats test_tags=exactness:fuzzy
 @test "has_expected_title" {
-    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
-
-    run bash -c "cat $QUERY_RESULTS | jq -r '.[0].title'"
+    run bash -c "cat $QUERY_RESULTS | jq -r '.rows.[0].title'"
     if [[ -z "$TITLE" ]]; then assert_output --partial $TITLE ; else assert_success ; fi
 }
 
 #bats test_tags=exactness:fuzzy
 @test "has_expected_person_id" {
-    if [[ ! -e $QUERY_RESULTS ]]; then skip ; fi
-
-    run bash -c "cat $QUERY_RESULTS | jq -r '.[0].detected_at'"
+    run bash -c "cat $QUERY_RESULTS | jq -r '.rows.[0].detected_at'"
     if [[ -z "$DETECTED_AT" ]]; then assert_output --partial $DETECTED_AT ; else assert_success ; fi
 }
 

--- a/test/end-to-end/kolide_unprocessable_entity.bats
+++ b/test/end-to-end/kolide_unprocessable_entity.bats
@@ -37,8 +37,8 @@ setup() {
 
 #bats test_tags=exactness:fuzzy
 @test "has_expected_person_id" {
-    run bash -c "cat $QUERY_RESULTS | jq -r '.rows.[0].detected_at'"
-    if [[ -z "$DETECTED_AT" ]]; then assert_output --partial $DETECTED_AT ; else assert_success ; fi
+    run bash -c "cat $QUERY_RESULTS | jq -r '.rows.[0].person_id'"
+    if [[ -z "$PERSON_ID" ]]; then assert_output --partial $PERSON_ID ; else assert_success ; fi
 }
 
 teardown_file(){


### PR DESCRIPTION
## Description

Implement GET /registration_requests and /registration_requests/{id} endpoints, together with revising tests to handle JSON output produced in Steampiper v0.23

## Related Tickets & Documents

Closes #38, #39

## Steps to Verify

Untested, insufficient data