### PR TITLE
chore(build): migrate goreleaser config

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,6 @@
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+version: 2
+
 before:
   hooks:
     - go mod tidy
@@ -29,7 +32,7 @@ builds:
       - -tags=netgo
 
 archives:
-  - format: gz
+  - formats: ['gz']
     name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
     files:
       - none*


### PR DESCRIPTION
## Description

Goreleaser v2 requires a `version` field in the configuration YAML file

## Related Tickets & Documents

None

## Steps to Verify

End-to-end and unit tests pass