### PR TITLE
fix(deps): refresh dependencies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,12 +2,12 @@ module github.com/grendel-consulting/steampipe-plugin-kolide
 
 go 1.24
 
-toolchain go1.24.2
+toolchain go1.24.4
 
 require (
 	github.com/imroc/req/v3 v3.52.2
 	github.com/onsi/gomega v1.37.0
-	github.com/turbot/steampipe-plugin-sdk/v5 v5.11.6
+	github.com/turbot/steampipe-plugin-sdk/v5 v5.11.7
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -562,8 +562,8 @@ github.com/tkrajina/go-reflector v0.5.8 h1:yPADHrwmUbMq4RGEyaOUpz2H90sRsETNVpjzo
 github.com/tkrajina/go-reflector v0.5.8/go.mod h1:ECbqLgccecY5kPmPmXg1MrHW585yMcDkVl6IvJe64T4=
 github.com/turbot/go-kit v1.1.0 h1:2gW+MFDJD+mN41GcvhAajTrwR8HgN9KKJ8HnYwPGTV0=
 github.com/turbot/go-kit v1.1.0/go.mod h1:1xmRuQ0cn/10QUMNLNOAFIqN8P6Rz5s3VLT8mkN3nF8=
-github.com/turbot/steampipe-plugin-sdk/v5 v5.11.6 h1:VYWMj5dPDQ2QZ1SAd8DKDygS6yk2DxY15c0IUf839qI=
-github.com/turbot/steampipe-plugin-sdk/v5 v5.11.6/go.mod h1:kkkm+Xb7r+WwKsn8tGVAaLtS6cPzqCpNK060N1xUmMQ=
+github.com/turbot/steampipe-plugin-sdk/v5 v5.11.7 h1:imNeaO3aJ/1aBu80cBPiikYIAApql/HuXrAjZdy4nGk=
+github.com/turbot/steampipe-plugin-sdk/v5 v5.11.7/go.mod h1:kkkm+Xb7r+WwKsn8tGVAaLtS6cPzqCpNK060N1xUmMQ=
 github.com/ulikunitz/xz v0.5.10/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/ulikunitz/xz v0.5.12 h1:37Nm15o69RwBkXM0J6A5OlE67RZTfzUxTj8fB3dfcsc=
 github.com/ulikunitz/xz v0.5.12/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=


### PR DESCRIPTION
## Description

Refreshes dependencies, since Renovate isn't handling Go modules

## Related Tickets & Documents

See: #380, #383

## Steps to Verify

End-to-end and unit tests pass