### PR TITLE
build: expand allowlisted action endpoints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
             objects.githubusercontent.com:443
             proxy.golang.org:443
             raw.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
             storage.googleapis.com:443
             sum.golang.org:443
 


### PR DESCRIPTION
## Description

Expand allowlisted endpoints to enable linters to run in CI

## Related Tickets & Documents

None

## Steps to Verify

Will re-run failint action job