### PR TITLE
fix: hanging bats tests

### DIFF
--- a/test/end-to-end/_results/kolide_unprocessable_entity.bash
+++ b/test/end-to-end/_results/kolide_unprocessable_entity.bash
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+define_test_results(){
+    # Unexpected behaviour in Kolide API under K2; this endpoint returns an empty list
+    export EXPECTED_COUNT="0"
+    # export TITLE=""
+    # export DETECTED_AT=""
+    # export BLOCKS_DEVICE_AT=""
+    # export RESOLVED_AT=""
+    # export EXEMPTED=""
+}

--- a/test/end-to-end/kolide_admin_user.bats
+++ b/test/end-to-end/kolide_admin_user.bats
@@ -18,7 +18,7 @@ setup() {
 
 #bats test_tags=scope:smoke
 @test "can_execute_query_via_steampipe" {
-    steampipe query $QUERY_UNDER_TEST --output json > $QUERY_RESULTS
+    steampipe query $QUERY_UNDER_TEST --output json > $QUERY_RESULTS 3>&-
     assert_exists $QUERY_RESULTS
 }
 

--- a/test/end-to-end/kolide_admin_user_by_id.bats
+++ b/test/end-to-end/kolide_admin_user_by_id.bats
@@ -12,7 +12,7 @@ setup() {
 
 #bats test_tags=scope:smoke
 @test "can_execute_query_via_steampipe" {
-    steampipe query $QUERY_UNDER_TEST --output json > $QUERY_RESULTS
+    steampipe query $QUERY_UNDER_TEST --output json > $QUERY_RESULTS 3>&-
     assert_exists $QUERY_RESULTS
 }
 

--- a/test/end-to-end/kolide_audit_log.bats
+++ b/test/end-to-end/kolide_audit_log.bats
@@ -18,7 +18,7 @@ setup() {
 
 #bats test_tags=scope:smoke
 @test "can_execute_query_via_steampipe" {
-    steampipe query $QUERY_UNDER_TEST --output json > $QUERY_RESULTS
+    steampipe query $QUERY_UNDER_TEST --output json > $QUERY_RESULTS 3>&-
     assert_exists $QUERY_RESULTS
 }
 

--- a/test/end-to-end/kolide_audit_log_by_id.bats
+++ b/test/end-to-end/kolide_audit_log_by_id.bats
@@ -12,7 +12,7 @@ setup() {
 
 #bats test_tags=scope:smoke
 @test "can_execute_query_via_steampipe" {
-    steampipe query $QUERY_UNDER_TEST --output json > $QUERY_RESULTS
+    steampipe query $QUERY_UNDER_TEST --output json > $QUERY_RESULTS 3>&-
     assert_exists $QUERY_RESULTS
 }
 

--- a/test/end-to-end/kolide_auth_log.bats
+++ b/test/end-to-end/kolide_auth_log.bats
@@ -18,7 +18,7 @@ setup() {
 
 #bats test_tags=scope:smoke
 @test "can_execute_query_via_steampipe" {
-    steampipe query $QUERY_UNDER_TEST --output json > $QUERY_RESULTS
+    steampipe query $QUERY_UNDER_TEST --output json > $QUERY_RESULTS 3>&-
     assert_exists $QUERY_RESULTS
 }
 

--- a/test/end-to-end/kolide_auth_log_by_id.bats
+++ b/test/end-to-end/kolide_auth_log_by_id.bats
@@ -12,7 +12,7 @@ setup() {
 
 #bats test_tags=scope:smoke
 @test "can_execute_query_via_steampipe" {
-    steampipe query $QUERY_UNDER_TEST --output json > $QUERY_RESULTS
+    steampipe query $QUERY_UNDER_TEST --output json > $QUERY_RESULTS 3>&-
     assert_exists $QUERY_RESULTS
 }
 

--- a/test/end-to-end/kolide_check.bats
+++ b/test/end-to-end/kolide_check.bats
@@ -18,7 +18,7 @@ setup() {
 
 #bats test_tags=scope:smoke
 @test "can_execute_query_via_steampipe" {
-    steampipe query $QUERY_UNDER_TEST --output json > $QUERY_RESULTS
+    steampipe query $QUERY_UNDER_TEST --output json > $QUERY_RESULTS 3>&-
     assert_exists $QUERY_RESULTS
 }
 

--- a/test/end-to-end/kolide_check_by_id.bats
+++ b/test/end-to-end/kolide_check_by_id.bats
@@ -12,7 +12,7 @@ setup() {
 
 #bats test_tags=scope:smoke
 @test "can_execute_query_via_steampipe" {
-    steampipe query $QUERY_UNDER_TEST --output json > $QUERY_RESULTS
+    steampipe query $QUERY_UNDER_TEST --output json > $QUERY_RESULTS 3>&-
     assert_exists $QUERY_RESULTS
 }
 

--- a/test/end-to-end/kolide_deprovisioned_person.bats
+++ b/test/end-to-end/kolide_deprovisioned_person.bats
@@ -18,7 +18,7 @@ setup() {
 
 #bats test_tags=scope:smoke
 @test "can_execute_query_via_steampipe" {
-    steampipe query $QUERY_UNDER_TEST --output json > $QUERY_RESULTS
+    steampipe query $QUERY_UNDER_TEST --output json > $QUERY_RESULTS 3>&-
     assert_exists $QUERY_RESULTS
 }
 

--- a/test/end-to-end/kolide_device.bats
+++ b/test/end-to-end/kolide_device.bats
@@ -18,7 +18,7 @@ setup() {
 
 #bats test_tags=scope:smoke
 @test "can_execute_query_via_steampipe" {
-    steampipe query $QUERY_UNDER_TEST --output json > $QUERY_RESULTS
+    steampipe query $QUERY_UNDER_TEST --output json > $QUERY_RESULTS 3>&-
     assert_exists $QUERY_RESULTS
 }
 

--- a/test/end-to-end/kolide_device_by_id.bats
+++ b/test/end-to-end/kolide_device_by_id.bats
@@ -12,7 +12,7 @@ setup() {
 
 #bats test_tags=scope:smoke
 @test "can_execute_query_via_steampipe" {
-    steampipe query $QUERY_UNDER_TEST --output json > $QUERY_RESULTS
+    steampipe query $QUERY_UNDER_TEST --output json > $QUERY_RESULTS 3>&-
     assert_exists $QUERY_RESULTS
 }
 

--- a/test/end-to-end/kolide_device_group.bats
+++ b/test/end-to-end/kolide_device_group.bats
@@ -15,6 +15,6 @@ setup() {
 @test "query_forbidden_under_billing_plan" {
     if [[ "$MY_KOLIDE_PLAN" != "K2" ]]; then skip; fi
 
-    run ! steampipe query $QUERY_UNDER_TEST
+    run ! steampipe query $QUERY_UNDER_TEST 3>&-
     assert_output --partial "403"
 }

--- a/test/end-to-end/kolide_device_group_by_id.bats
+++ b/test/end-to-end/kolide_device_group_by_id.bats
@@ -15,6 +15,6 @@ setup() {
 @test "query_forbidden_under_billing_plan" {
     if [[ "$MY_KOLIDE_PLAN" != "K2" ]]; then skip; fi
 
-    run ! steampipe query $QUERY_UNDER_TEST
+    run ! steampipe query $QUERY_UNDER_TEST 3>&-
     assert_output --partial "403"
 }

--- a/test/end-to-end/kolide_device_group_device.bats
+++ b/test/end-to-end/kolide_device_group_device.bats
@@ -15,6 +15,6 @@ setup() {
 @test "query_forbidden_under_billing_plan" {
     if [[ "$MY_KOLIDE_PLAN" != "K2" ]]; then skip; fi
 
-    run ! steampipe query $QUERY_UNDER_TEST
+    run ! steampipe query $QUERY_UNDER_TEST 3>&-
     assert_output --partial "403"
 }

--- a/test/end-to-end/kolide_device_open_issue.bats
+++ b/test/end-to-end/kolide_device_open_issue.bats
@@ -18,7 +18,7 @@ setup() {
 
 #bats test_tags=scope:smoke
 @test "can_execute_query_via_steampipe" {
-    steampipe query $QUERY_UNDER_TEST --output json > $QUERY_RESULTS
+    steampipe query $QUERY_UNDER_TEST --output json > $QUERY_RESULTS 3>&-
     assert_exists $QUERY_RESULTS
 }
 

--- a/test/end-to-end/kolide_exemption_request.bats
+++ b/test/end-to-end/kolide_exemption_request.bats
@@ -18,7 +18,7 @@ setup() {
 
 #bats test_tags=scope:smoke
 @test "can_execute_query_via_steampipe" {
-    steampipe query $QUERY_UNDER_TEST --output json > $QUERY_RESULTS
+    steampipe query $QUERY_UNDER_TEST --output json > $QUERY_RESULTS 3>&-
     assert_exists $QUERY_RESULTS
 }
 

--- a/test/end-to-end/kolide_exemption_request_by_id.bats
+++ b/test/end-to-end/kolide_exemption_request_by_id.bats
@@ -12,7 +12,7 @@ setup() {
 
 #bats test_tags=scope:smoke
 @test "can_execute_query_via_steampipe" {
-    steampipe query $QUERY_UNDER_TEST --output json > $QUERY_RESULTS
+    steampipe query $QUERY_UNDER_TEST --output json > $QUERY_RESULTS 3>&-
     assert_exists $QUERY_RESULTS
 }
 

--- a/test/end-to-end/kolide_issue.bats
+++ b/test/end-to-end/kolide_issue.bats
@@ -18,7 +18,7 @@ setup() {
 
 #bats test_tags=scope:smoke
 @test "can_execute_query_via_steampipe" {
-    steampipe query $QUERY_UNDER_TEST --output json > $QUERY_RESULTS
+    steampipe query $QUERY_UNDER_TEST --output json > $QUERY_RESULTS 3>&-
     assert_exists $QUERY_RESULTS
 }
 

--- a/test/end-to-end/kolide_issue_by_id.bats
+++ b/test/end-to-end/kolide_issue_by_id.bats
@@ -12,7 +12,7 @@ setup() {
 
 #bats test_tags=scope:smoke
 @test "can_execute_query_via_steampipe" {
-    steampipe query $QUERY_UNDER_TEST --output json > $QUERY_RESULTS
+    steampipe query $QUERY_UNDER_TEST --output json > $QUERY_RESULTS 3>&-
     assert_exists $QUERY_RESULTS
 }
 

--- a/test/end-to-end/kolide_live_query_campaign.bats
+++ b/test/end-to-end/kolide_live_query_campaign.bats
@@ -15,6 +15,6 @@ setup() {
 @test "query_forbidden_under_billing_plan" {
     if [[ "$MY_KOLIDE_PLAN" != "K2" ]]; then skip; fi
 
-    run ! steampipe query $QUERY_UNDER_TEST
+    run ! steampipe query $QUERY_UNDER_TEST 3>&-
     assert_output --partial "403"
 }

--- a/test/end-to-end/kolide_live_query_campaign_by_id.bats
+++ b/test/end-to-end/kolide_live_query_campaign_by_id.bats
@@ -15,6 +15,6 @@ setup() {
 @test "query_forbidden_under_billing_plan" {
     if [[ "$MY_KOLIDE_PLAN" != "K2" ]]; then skip; fi
 
-    run ! steampipe query $QUERY_UNDER_TEST
+    run ! steampipe query $QUERY_UNDER_TEST 3>&-
     assert_output --partial "403"
 }

--- a/test/end-to-end/kolide_package_by_id.bats
+++ b/test/end-to-end/kolide_package_by_id.bats
@@ -12,7 +12,7 @@ setup() {
 
 #bats test_tags=scope:smoke
 @test "can_execute_query_via_steampipe" {
-    steampipe query $QUERY_UNDER_TEST --output json > $QUERY_RESULTS
+    steampipe query $QUERY_UNDER_TEST --output json > $QUERY_RESULTS 3>&-
     assert_exists $QUERY_RESULTS
 }
 

--- a/test/end-to-end/kolide_person.bats
+++ b/test/end-to-end/kolide_person.bats
@@ -18,7 +18,7 @@ setup() {
 
 #bats test_tags=scope:smoke
 @test "can_execute_query_via_steampipe" {
-    steampipe query $QUERY_UNDER_TEST --output json > $QUERY_RESULTS
+    steampipe query $QUERY_UNDER_TEST --output json > $QUERY_RESULTS 3>&-
     assert_exists $QUERY_RESULTS
 }
 

--- a/test/end-to-end/kolide_person_by_id.bats
+++ b/test/end-to-end/kolide_person_by_id.bats
@@ -12,7 +12,7 @@ setup() {
 
 #bats test_tags=scope:smoke
 @test "can_execute_query_via_steampipe" {
-    steampipe query $QUERY_UNDER_TEST --output json > $QUERY_RESULTS
+    steampipe query $QUERY_UNDER_TEST --output json > $QUERY_RESULTS 3>&-
     assert_exists $QUERY_RESULTS
 }
 

--- a/test/end-to-end/kolide_person_group.bats
+++ b/test/end-to-end/kolide_person_group.bats
@@ -15,6 +15,6 @@ setup() {
 @test "query_forbidden_under_billing_plan" {
     if [[ "$MY_KOLIDE_PLAN" != "K2" ]]; then skip; fi
 
-    run ! steampipe query $QUERY_UNDER_TEST
+    run ! steampipe query $QUERY_UNDER_TEST 3>&-
     assert_output --partial "403"
 }

--- a/test/end-to-end/kolide_person_group_by_id.bats
+++ b/test/end-to-end/kolide_person_group_by_id.bats
@@ -15,6 +15,6 @@ setup() {
 @test "query_forbidden_under_billing_plan" {
     if [[ "$MY_KOLIDE_PLAN" != "K2" ]]; then skip; fi
 
-    run ! steampipe query $QUERY_UNDER_TEST
+    run ! steampipe query $QUERY_UNDER_TEST 3>&-
     assert_output --partial "403"
 }

--- a/test/end-to-end/kolide_person_open_issue.bats
+++ b/test/end-to-end/kolide_person_open_issue.bats
@@ -18,7 +18,7 @@ setup() {
 
 #bats test_tags=scope:smoke
 @test "can_execute_query_via_steampipe" {
-    steampipe query $QUERY_UNDER_TEST --output json > $QUERY_RESULTS
+    steampipe query $QUERY_UNDER_TEST --output json > $QUERY_RESULTS 3>&-
     assert_exists $QUERY_RESULTS
 }
 

--- a/test/end-to-end/kolide_person_registered_device.bats
+++ b/test/end-to-end/kolide_person_registered_device.bats
@@ -18,7 +18,7 @@ setup() {
 
 #bats test_tags=scope:smoke
 @test "can_execute_query_via_steampipe" {
-    steampipe query $QUERY_UNDER_TEST --output json > $QUERY_RESULTS
+    steampipe query $QUERY_UNDER_TEST --output json > $QUERY_RESULTS 3>&-
     assert_exists $QUERY_RESULTS
 }
 

--- a/test/end-to-end/kolide_registration_request.bats
+++ b/test/end-to-end/kolide_registration_request.bats
@@ -18,7 +18,7 @@ setup() {
 
 #bats test_tags=scope:smoke
 @test "can_execute_query_via_steampipe" {
-    steampipe query $QUERY_UNDER_TEST --output json > $QUERY_RESULTS
+    steampipe query $QUERY_UNDER_TEST --output json > $QUERY_RESULTS 3>&-
     assert_exists $QUERY_RESULTS
 }
 

--- a/test/end-to-end/kolide_registration_request_by_id.bats
+++ b/test/end-to-end/kolide_registration_request_by_id.bats
@@ -12,7 +12,7 @@ setup() {
 
 #bats test_tags=scope:smoke
 @test "can_execute_query_via_steampipe" {
-    steampipe query $QUERY_UNDER_TEST --output json > $QUERY_RESULTS
+    steampipe query $QUERY_UNDER_TEST --output json > $QUERY_RESULTS 3>&-
     assert_exists $QUERY_RESULTS
 }
 

--- a/test/end-to-end/kolide_unprocessable_entity.bats
+++ b/test/end-to-end/kolide_unprocessable_entity.bats
@@ -1,4 +1,4 @@
-# bats file_tags=table:kolide_package, output:package
+# bats file_tags=table:kolide_person_open_issue, output:issue
 
 setup_file() {
     load "${BATS_TEST_DIRNAME}/_support/globals.bash"
@@ -16,7 +16,8 @@ setup() {
     load_helpers
 }
 
-#bats test_tags=scope:smoke
+# Regression test for https://github.com/grendel-consulting/steampipe-plugin-kolide/issues/129
+#bats test_tags=scope:regression
 @test "can_execute_query_via_steampipe" {
     steampipe query $QUERY_UNDER_TEST --output json > $QUERY_RESULTS 3>&-
     assert_exists $QUERY_RESULTS
@@ -28,26 +29,16 @@ setup() {
     if [[ -z "$EXPECTED_COUNT" ]]; then assert_output $EXPECTED_COUNT ; else assert [ "$output" -ge "1" ] ; fi
 }
 
-@test "has_expected_id" {
-    run bash -c "cat $QUERY_RESULTS | jq -r '.rows.[0].id'"
-    if [[ -z "$ID" ]]; then assert_output $ID ; else assert_success ; fi
+#bats test_tags=exactness:fuzzy
+@test "has_expected_title" {
+    run bash -c "cat $QUERY_RESULTS | jq -r '.rows.[0].title'"
+    if [[ -z "$TITLE" ]]; then assert_output --partial $TITLE ; else assert_success ; fi
 }
 
 #bats test_tags=exactness:fuzzy
-@test "has_expected_built_at" {
-    run bash -c "cat $QUERY_RESULTS | jq -r '.rows.[0].built_at'"
-    if [[ -z "$BUILT_AT" ]]; then assert_output --partial $BUILT_AT ; else assert_success ; fi
-}
-
-@test "has_expected_version" {
-    run bash -c "cat $QUERY_RESULTS | jq -r '.rows.[0].version'"
-    if [[ -z "$VERSION" ]]; then assert_output $VERSION ; else assert_success ; fi
-}
-
-
-@test "has_expected_url" {
-    run bash -c "cat $QUERY_RESULTS | jq -r '.rows.[0].url'"
-    if [[ -z "$URL" ]]; then assert_output $URL ; else assert_success ; fi
+@test "has_expected_person_id" {
+    run bash -c "cat $QUERY_RESULTS | jq -r '.rows.[0].person_id'"
+    if [[ -z "$PERSON_ID" ]]; then assert_output --partial $PERSON_ID ; else assert_success ; fi
 }
 
 teardown_file(){


### PR DESCRIPTION
## Description

Starting to see some combined test runs hang, where longer running `steampipe` queries are not closing file descriptors properly and hence `bats` will not exit cleanly - though all tests pass

## Related Tickets & Documents

See: https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs

## Steps to Verify

End-to-end and unit tests pass