### PR TITLE
chore(deps): refresh dependencies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.25.1
 require (
 	github.com/imroc/req/v3 v3.55.0
 	github.com/onsi/gomega v1.38.2
-	github.com/turbot/steampipe-plugin-sdk/v5 v5.13.0
+	github.com/turbot/steampipe-plugin-sdk/v5 v5.13.1
 )
 
 require go.yaml.in/yaml/v3 v3.0.4 // indirect
@@ -111,7 +111,7 @@ require (
 	github.com/stevenle/topsort v0.2.0 // indirect
 	github.com/tkrajina/go-reflector v0.5.8 // indirect
 	github.com/turbot/go-kit v1.1.0 // indirect
-	github.com/ulikunitz/xz v0.5.14 // indirect
+	github.com/ulikunitz/xz v0.5.15 // indirect
 	github.com/zclconf/go-cty v1.15.1 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.57.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1067,11 +1067,11 @@ github.com/tkrajina/go-reflector v0.5.8 h1:yPADHrwmUbMq4RGEyaOUpz2H90sRsETNVpjzo
 github.com/tkrajina/go-reflector v0.5.8/go.mod h1:ECbqLgccecY5kPmPmXg1MrHW585yMcDkVl6IvJe64T4=
 github.com/turbot/go-kit v1.1.0 h1:2gW+MFDJD+mN41GcvhAajTrwR8HgN9KKJ8HnYwPGTV0=
 github.com/turbot/go-kit v1.1.0/go.mod h1:1xmRuQ0cn/10QUMNLNOAFIqN8P6Rz5s3VLT8mkN3nF8=
-github.com/turbot/steampipe-plugin-sdk/v5 v5.13.0 h1:6GSmiKsPdMd2X1ULK17Q/8UQvNOpyub4F2a5nmMGkis=
-github.com/turbot/steampipe-plugin-sdk/v5 v5.13.0/go.mod h1:C4Ogzsd9ea97e7MJF3g/5k/8S0Ec8/iqAlPmr6zGXHA=
+github.com/turbot/steampipe-plugin-sdk/v5 v5.13.1 h1:XiZ3Sh25JhSJXOaw/j8N3ykSTFuxUNO7kKmnnJNr0Fk=
+github.com/turbot/steampipe-plugin-sdk/v5 v5.13.1/go.mod h1:5mZnBnYCi3FOsbX54QvTAw06GOyLe2EO5hOEugiiKvk=
 github.com/ulikunitz/xz v0.5.10/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
-github.com/ulikunitz/xz v0.5.14 h1:uv/0Bq533iFdnMHZdRBTOlaNMdb1+ZxXIlHDZHIHcvg=
-github.com/ulikunitz/xz v0.5.14/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
+github.com/ulikunitz/xz v0.5.15 h1:9DNdB5s+SgV3bQ2ApL10xRc35ck0DuIX/isZvIk+ubY=
+github.com/ulikunitz/xz v0.5.15/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/xyproto/randomstring v1.0.5 h1:YtlWPoRdgMu3NZtP45drfy1GKoojuR7hmRcnhZqKjWU=
 github.com/xyproto/randomstring v1.0.5/go.mod h1:rgmS5DeNXLivK7YprL0pY+lTuhNQW3iGxZ18UQApw/E=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=


### PR DESCRIPTION
## Description

Refreshes dependencies, since Renovate isn't handling Go modules

## Related Tickets & Documents

See: #448

## Steps to Verify

End-to-end and unit tests pass