### PR TITLE
chore: prepare to archive repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Kolide plugin for Steampipe
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/8741/badge)](https://www.bestpractices.dev/projects/8741)[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/grendel-consulting/steampipe-plugin-kolide/badge)](https://securityscorecards.dev/viewer/?uri=github.com/grendel-consulting/steampipe-plugin-kolide)[![Go Report Card](https://goreportcard.com/badge/github.com/grendel-consulting/steampipe-plugin-kolide)](https://goreportcard.com/report/github.com/grendel-consulting/steampipe-plugin-kolide)
 
-Use SQL to query Devices, People, Checks, Issues and more across your [Kolide](https://www.kolide.com/) fleet. Built atop the [Kolide API](https://www.kolide.com/docs/developers/api).
+Use SQL to query Devices, People, Checks, Issues and more across your [Kolide](https://www.kolide.com/) fleet. Built atop the [Kolide API](https://www.kolide.com/docs/developers/api), which has now been deprecated.
 
 ## Quick Start
 

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,6 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "enabled": false,
     "extends": [
       "config:best-practices",
       "schedule:nonOfficeHours",


### PR DESCRIPTION
## Description

Prepare the repo for archiving now the Kolide K2 API is deprecated

## Related Tickets & Documents

See: https://www.kolide.com/docs/developers/v0-api-deprecation

## Steps to Verify

Nothing to verify